### PR TITLE
Ft subject detail

### DIFF
--- a/pkg/cacheimpls/subject_detail.go
+++ b/pkg/cacheimpls/subject_detail.go
@@ -27,7 +27,8 @@ func retrieveSubjectDetail(key cache.Key) (interface{}, error) {
 		return nil, err
 	}
 
-	groups, err := svc.GetThinSubjectGroups(k.PK)
+	// NOTE: 这里只获取当前有效的 subject-groups, 之后放入缓存; 使用的时候, 会再次过滤掉已过期的(入缓存时可能还没过期, 使用时过期)
+	groups, err := svc.GetEffectThinSubjectGroups(k.PK)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cacheimpls/subject_group.go
+++ b/pkg/cacheimpls/subject_group.go
@@ -24,7 +24,7 @@ func retrieveSubjectGroups(key cache.Key) (interface{}, error) {
 	k := key.(SubjectPKCacheKey)
 
 	svc := service.NewSubjectService()
-	return svc.GetThinSubjectGroups(k.PK)
+	return svc.GetEffectThinSubjectGroups(k.PK)
 }
 
 // TODO: remove this cache? => if we can know a department add or remove from a group?

--- a/pkg/cacheimpls/subject_group.go
+++ b/pkg/cacheimpls/subject_group.go
@@ -62,9 +62,9 @@ func ListSubjectEffectGroups(pks []int64) ([]types.ThinSubjectGroup, error) {
 	// 3. ids of no cache, retrieve multiple
 	svc := service.NewSubjectService()
 	// 按照时间过滤, 不应该查已过期的回来
-	notCachedSubjectGroups, err := svc.ListSubjectEffectGroups(notExistCachePKs)
+	notCachedSubjectGroups, err := svc.ListEffectThinSubjectGroups(notExistCachePKs)
 	if err != nil {
-		err = errorWrapf(err, "SubjectService.ListSubjectEffectGroups pks=`%v` fail", notExistCachePKs)
+		err = errorWrapf(err, "SubjectService.ListEffectThinSubjectGroups pks=`%v` fail", notExistCachePKs)
 		return nil, err
 	}
 	setMissing(notCachedSubjectGroups, notExistCachePKs)

--- a/pkg/cacheimpls/subject_group_test.go
+++ b/pkg/cacheimpls/subject_group_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SubjectGroups", func() {
 		defer ctl.Finish()
 
 		mockService := mock.NewMockSubjectService(ctl)
-		mockService.EXPECT().GetThinSubjectGroups(int64(1)).Return([]types.ThinSubjectGroup{
+		mockService.EXPECT().GetEffectThinSubjectGroups(int64(1)).Return([]types.ThinSubjectGroup{
 			{
 				PK:              int64(1),
 				PolicyExpiredAt: int64(100000),
@@ -125,7 +125,7 @@ var _ = Describe("SubjectGroups", func() {
 
 			It("has no cached, get from database fail", func() {
 				mockService := mock.NewMockSubjectService(ctl)
-				mockService.EXPECT().ListSubjectEffectGroups([]int64{1}).Return(
+				mockService.EXPECT().ListEffectThinSubjectGroups([]int64{1}).Return(
 					nil, errors.New("error")).AnyTimes()
 
 				patches.ApplyFunc(service.NewSubjectService,
@@ -136,11 +136,11 @@ var _ = Describe("SubjectGroups", func() {
 				// call
 				_, err := ListSubjectEffectGroups([]int64{1, 2, 3})
 				assert.Error(GinkgoT(), err)
-				assert.Contains(GinkgoT(), err.Error(), "SubjectService.ListSubjectEffectGroups")
+				assert.Contains(GinkgoT(), err.Error(), "SubjectService.ListEffectThinSubjectGroups")
 			})
 			It("has no cached, get from database success", func() {
 				mockService := mock.NewMockSubjectService(ctl)
-				mockService.EXPECT().ListSubjectEffectGroups([]int64{1}).Return(
+				mockService.EXPECT().ListEffectThinSubjectGroups([]int64{1}).Return(
 					map[int64][]types.ThinSubjectGroup{
 						int64(1): {
 							{
@@ -163,7 +163,7 @@ var _ = Describe("SubjectGroups", func() {
 
 			It("has no cached, get from database success, has empty cached", func() {
 				mockService := mock.NewMockSubjectService(ctl)
-				mockService.EXPECT().ListSubjectEffectGroups([]int64{1}).Return(
+				mockService.EXPECT().ListEffectThinSubjectGroups([]int64{1}).Return(
 					map[int64][]types.ThinSubjectGroup{}, nil).AnyTimes()
 
 				patches.ApplyFunc(service.NewSubjectService,

--- a/pkg/database/dao/mock/subject_relation.go
+++ b/pkg/database/dao/mock/subject_relation.go
@@ -64,19 +64,19 @@ func (mr *MockSubjectRelationManagerMockRecorder) ListRelationBySubjectPK(subjec
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelationBySubjectPK), subjectPK)
 }
 
-// ListThinRelationBySubjectPK mocks base method
-func (m *MockSubjectRelationManager) ListThinRelationBySubjectPK(subjectPK int64) ([]dao.ThinSubjectRelation, error) {
+// ListEffectThinRelationBySubjectPK mocks base method
+func (m *MockSubjectRelationManager) ListEffectThinRelationBySubjectPK(subjectPK int64) ([]dao.ThinSubjectRelation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinRelationBySubjectPK", subjectPK)
+	ret := m.ctrl.Call(m, "ListEffectThinRelationBySubjectPK", subjectPK)
 	ret0, _ := ret[0].([]dao.ThinSubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListThinRelationBySubjectPK indicates an expected call of ListThinRelationBySubjectPK
-func (mr *MockSubjectRelationManagerMockRecorder) ListThinRelationBySubjectPK(subjectPK interface{}) *gomock.Call {
+// ListEffectThinRelationBySubjectPK indicates an expected call of ListEffectThinRelationBySubjectPK
+func (mr *MockSubjectRelationManagerMockRecorder) ListEffectThinRelationBySubjectPK(subjectPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListThinRelationBySubjectPK), subjectPK)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListEffectThinRelationBySubjectPK), subjectPK)
 }
 
 // ListEffectRelationBySubjectPKs mocks base method

--- a/pkg/database/dao/subject_relation.go
+++ b/pkg/database/dao/subject_relation.go
@@ -15,12 +15,11 @@ package dao
 import (
 	"database/sql"
 	"errors"
-
 	"time"
 
-	"iam/pkg/database"
-
 	"github.com/jmoiron/sqlx"
+
+	"iam/pkg/database"
 )
 
 // SubjectRelation  用户-组/部门-组关系表
@@ -62,7 +61,7 @@ type EffectSubjectRelation struct {
 type SubjectRelationManager interface {
 	ListRelation(_type, id string) ([]SubjectRelation, error)
 	ListRelationBySubjectPK(subjectPK int64) ([]SubjectRelation, error)
-	ListThinRelationBySubjectPK(subjectPK int64) ([]ThinSubjectRelation, error)
+	ListEffectThinRelationBySubjectPK(subjectPK int64) ([]ThinSubjectRelation, error)
 	ListEffectRelationBySubjectPKs(subjectPKs []int64) ([]EffectSubjectRelation, error)
 	ListRelationBeforeExpiredAt(_type, id string, expiredAt int64) ([]SubjectRelation, error)
 
@@ -126,10 +125,14 @@ func (m *subjectRelationManager) ListRelationBySubjectPK(subjectPK int64) (relat
 	return
 }
 
-// ListThinRelationBySubjectPK ...
-func (m *subjectRelationManager) ListThinRelationBySubjectPK(subjectPK int64) (
+// ListEffectThinRelationBySubjectPK ...
+func (m *subjectRelationManager) ListEffectThinRelationBySubjectPK(subjectPK int64) (
 	relations []ThinSubjectRelation, err error) {
-	err = m.selectThinRelationBySubjectPK(&relations, subjectPK)
+
+	// 过期时间必须大于当前时间
+	now := time.Now().Unix()
+
+	err = m.selectEffectThinRelationBySubjectPK(&relations, subjectPK, now)
 	// 吞掉记录不存在的错误, subject本身是可以不加入任何用户组和组织的
 	if errors.Is(err, sql.ErrNoRows) {
 		return relations, nil
@@ -305,13 +308,18 @@ func (m *subjectRelationManager) selectRelationBySubjectPK(relations *[]SubjectR
 	return database.SqlxSelect(m.DB, relations, query, pk)
 }
 
-func (m *subjectRelationManager) selectThinRelationBySubjectPK(relations *[]ThinSubjectRelation, pk int64) error {
+func (m *subjectRelationManager) selectEffectThinRelationBySubjectPK(
+	relations *[]ThinSubjectRelation,
+	pk int64,
+	now int64,
+) error {
 	query := `SELECT
 		parent_pk,
 		policy_expired_at
 		FROM subject_relation
-		WHERE subject_pk = ?`
-	return database.SqlxSelect(m.DB, relations, query, pk)
+		WHERE subject_pk = ?
+		AND policy_expired_at > ?`
+	return database.SqlxSelect(m.DB, relations, query, pk, now)
 }
 
 func (m *subjectRelationManager) selectEffectRelationBySubjectPKs(

--- a/pkg/service/mock/subject.go
+++ b/pkg/service/mock/subject.go
@@ -181,19 +181,19 @@ func (mr *MockSubjectServiceMockRecorder) GetEffectThinSubjectGroups(pk interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).GetEffectThinSubjectGroups), pk)
 }
 
-// ListSubjectEffectGroups mocks base method
-func (m *MockSubjectService) ListSubjectEffectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error) {
+// ListEffectThinSubjectGroups mocks base method
+func (m *MockSubjectService) ListEffectThinSubjectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSubjectEffectGroups", pks)
+	ret := m.ctrl.Call(m, "ListEffectThinSubjectGroups", pks)
 	ret0, _ := ret[0].(map[int64][]types.ThinSubjectGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListSubjectEffectGroups indicates an expected call of ListSubjectEffectGroups
-func (mr *MockSubjectServiceMockRecorder) ListSubjectEffectGroups(pks interface{}) *gomock.Call {
+// ListEffectThinSubjectGroups indicates an expected call of ListEffectThinSubjectGroups
+func (mr *MockSubjectServiceMockRecorder) ListEffectThinSubjectGroups(pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectEffectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListSubjectEffectGroups), pks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListEffectThinSubjectGroups), pks)
 }
 
 // ListSubjectGroups mocks base method

--- a/pkg/service/mock/subject.go
+++ b/pkg/service/mock/subject.go
@@ -166,19 +166,19 @@ func (mr *MockSubjectServiceMockRecorder) BulkUpdateName(subjects interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateName", reflect.TypeOf((*MockSubjectService)(nil).BulkUpdateName), subjects)
 }
 
-// GetThinSubjectGroups mocks base method
-func (m *MockSubjectService) GetThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error) {
+// GetEffectThinSubjectGroups mocks base method
+func (m *MockSubjectService) GetEffectThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThinSubjectGroups", pk)
+	ret := m.ctrl.Call(m, "GetEffectThinSubjectGroups", pk)
 	ret0, _ := ret[0].([]types.ThinSubjectGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetThinSubjectGroups indicates an expected call of GetThinSubjectGroups
-func (mr *MockSubjectServiceMockRecorder) GetThinSubjectGroups(pk interface{}) *gomock.Call {
+// GetEffectThinSubjectGroups indicates an expected call of GetEffectThinSubjectGroups
+func (mr *MockSubjectServiceMockRecorder) GetEffectThinSubjectGroups(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).GetThinSubjectGroups), pk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).GetEffectThinSubjectGroups), pk)
 }
 
 // ListSubjectEffectGroups mocks base method

--- a/pkg/service/subject.go
+++ b/pkg/service/subject.go
@@ -39,7 +39,7 @@ type SubjectService interface {
 
 	// in subject_group.go
 
-	GetThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error)
+	GetEffectThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error)
 	ListSubjectEffectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error)
 	ListSubjectGroups(_type, id string, beforeExpiredAt int64) ([]types.SubjectGroup, error)
 

--- a/pkg/service/subject.go
+++ b/pkg/service/subject.go
@@ -40,7 +40,7 @@ type SubjectService interface {
 	// in subject_group.go
 
 	GetEffectThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error)
-	ListSubjectEffectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error)
+	ListEffectThinSubjectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error)
 	ListSubjectGroups(_type, id string, beforeExpiredAt int64) ([]types.SubjectGroup, error)
 
 	// in subject_member.go

--- a/pkg/service/subject_group.go
+++ b/pkg/service/subject_group.go
@@ -41,12 +41,13 @@ func convertEffectiveRelationToThinSubjectGroup(effectRelation dao.EffectSubject
 	}
 }
 
-// GetThinSubjectGroups 获取授权对象的用户组(只返回groupPK/policyExpiredAt)
-func (l *subjectService) GetThinSubjectGroups(pk int64) (thinSubjectGroup []types.ThinSubjectGroup, err error) {
-	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "GetThinSubjectGroups")
-	relations, err := l.relationManager.ListThinRelationBySubjectPK(pk)
+// GetEffectThinSubjectGroups 获取授权对象的用户组(只返回groupPK/policyExpiredAt)
+func (l *subjectService) GetEffectThinSubjectGroups(pk int64) (thinSubjectGroup []types.ThinSubjectGroup, err error) {
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "GetEffectThinSubjectGroups")
+
+	relations, err := l.relationManager.ListEffectThinRelationBySubjectPK(pk)
 	if err != nil {
-		return thinSubjectGroup, errorWrapf(err, "ListRelationByPK pk=`%d` fail", pk)
+		return thinSubjectGroup, errorWrapf(err, "ListEffectThinRelationBySubjectPK pk=`%d` fail", pk)
 	}
 
 	for _, r := range relations {

--- a/pkg/service/subject_group.go
+++ b/pkg/service/subject_group.go
@@ -56,10 +56,11 @@ func (l *subjectService) GetEffectThinSubjectGroups(pk int64) (thinSubjectGroup 
 	return thinSubjectGroup, err
 }
 
-// ListSubjectEffectGroups 批量获取 subject 有效的 groups(未过期的)
-func (l *subjectService) ListSubjectEffectGroups(pks []int64) (
-	subjectGroups map[int64][]types.ThinSubjectGroup, err error) {
-	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "ListSubjectEffectGroups")
+// ListEffectThinSubjectGroups 批量获取 subject 有效的 groups(未过期的)
+func (l *subjectService) ListEffectThinSubjectGroups(
+	pks []int64,
+) (subjectGroups map[int64][]types.ThinSubjectGroup, err error) {
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "ListEffectThinSubjectGroups")
 
 	subjectGroups = make(map[int64][]types.ThinSubjectGroup, len(pks))
 


### PR DESCRIPTION
- GetThinSubjectGroups 重构成 GetEffectThinSubjectGroups, 只获取目前还有效的 `用户-组`列表
- service 层原 ListSubjectEffectGroups 重命名为 ListEffectThinSubjectGroups