### PR TITLE
Ft subject relation change

### DIFF
--- a/build/support-files/sql/0021_iam_20220517-1502_mysql.sql
+++ b/build/support-files/sql/0021_iam_20220517-1502_mysql.sql
@@ -1,0 +1,15 @@
+-- drop index
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_uk_subject_parent;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_subject;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_parent;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_subject_pk_expire;
+
+-- drop column
+ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `subject_type`;
+ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `subject_id`;
+ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `parent_type`;
+ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `parent_id`;
+
+-- create index
+CREATE UNIQUE INDEX idx_uk_parent_subject ON `bkiam`.`subject_relation` (`parent_pk`,`subject_pk`);
+CREATE INDEX idx_subject_parent_expire ON `bkiam`.`subject_relation` (`subject_pk`,`parent_pk`,`policy_expired_at`);

--- a/build/support-files/sql/0021_iam_20220517-1502_mysql.sql
+++ b/build/support-files/sql/0021_iam_20220517-1502_mysql.sql
@@ -1,8 +1,8 @@
 -- drop index
-ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_uk_subject_parent;
-ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_subject;
-ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_parent;
-ALTER TABLE `bkiam`.`subject_relation` DROP INDEX idx_subject_pk_expire;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX `idx_uk_subject_parent`;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX `idx_subject`;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX `idx_parent`;
+ALTER TABLE `bkiam`.`subject_relation` DROP INDEX `idx_subject_pk_expire`;
 
 -- drop column
 ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `subject_type`;
@@ -11,5 +11,5 @@ ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `parent_type`;
 ALTER TABLE `bkiam`.`subject_relation` DROP COLUMN `parent_id`;
 
 -- create index
-CREATE UNIQUE INDEX idx_uk_parent_subject ON `bkiam`.`subject_relation` (`parent_pk`,`subject_pk`);
-CREATE INDEX idx_subject_parent_expire ON `bkiam`.`subject_relation` (`subject_pk`,`parent_pk`,`policy_expired_at`);
+CREATE UNIQUE INDEX `idx_uk_parent_subject` ON `bkiam`.`subject_relation` (`parent_pk`,`subject_pk`);
+CREATE INDEX `idx_subject_parent_expire` ON `bkiam`.`subject_relation` (`subject_pk`,`parent_pk`,`policy_expired_at`);

--- a/pkg/abac/prp/mock/policy.go
+++ b/pkg/abac/prp/mock/policy.go
@@ -5,97 +5,38 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/abac/types"
 	debug "iam/pkg/logging/debug"
 	types0 "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockPolicyManager is a mock of PolicyManager interface
+// MockPolicyManager is a mock of PolicyManager interface.
 type MockPolicyManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockPolicyManagerMockRecorder
 }
 
-// MockPolicyManagerMockRecorder is the mock recorder for MockPolicyManager
+// MockPolicyManagerMockRecorder is the mock recorder for MockPolicyManager.
 type MockPolicyManagerMockRecorder struct {
 	mock *MockPolicyManager
 }
 
-// NewMockPolicyManager creates a new mock instance
+// NewMockPolicyManager creates a new mock instance.
 func NewMockPolicyManager(ctrl *gomock.Controller) *MockPolicyManager {
 	mock := &MockPolicyManager{ctrl: ctrl}
 	mock.recorder = &MockPolicyManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPolicyManager) EXPECT() *MockPolicyManagerMockRecorder {
 	return m.recorder
 }
 
-// GetByActionTemplate mocks base method
-func (m *MockPolicyManager) GetByActionTemplate(system, subjectType, subjectID, actionID string, templateID int64) (types.AuthPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByActionTemplate", system, subjectType, subjectID, actionID, templateID)
-	ret0, _ := ret[0].(types.AuthPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByActionTemplate indicates an expected call of GetByActionTemplate
-func (mr *MockPolicyManagerMockRecorder) GetByActionTemplate(system, subjectType, subjectID, actionID, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).GetByActionTemplate), system, subjectType, subjectID, actionID, templateID)
-}
-
-// ListBySubjectAction mocks base method
-func (m *MockPolicyManager) ListBySubjectAction(system string, subject types.Subject, action types.Action, withoutCache bool, entry *debug.Entry) ([]types.AuthPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySubjectAction", system, subject, action, withoutCache, entry)
-	ret0, _ := ret[0].([]types.AuthPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySubjectAction indicates an expected call of ListBySubjectAction
-func (mr *MockPolicyManagerMockRecorder) ListBySubjectAction(system, subject, action, withoutCache, entry interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectAction", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectAction), system, subject, action, withoutCache, entry)
-}
-
-// ListSaaSBySubjectSystemTemplate mocks base method
-func (m *MockPolicyManager) ListSaaSBySubjectSystemTemplate(system, subjectType, subjectID string, templateID int64) ([]types.SaaSPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSaaSBySubjectSystemTemplate", system, subjectType, subjectID, templateID)
-	ret0, _ := ret[0].([]types.SaaSPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSaaSBySubjectSystemTemplate indicates an expected call of ListSaaSBySubjectSystemTemplate
-func (mr *MockPolicyManagerMockRecorder) ListSaaSBySubjectSystemTemplate(system, subjectType, subjectID, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSaaSBySubjectSystemTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListSaaSBySubjectSystemTemplate), system, subjectType, subjectID, templateID)
-}
-
-// ListSaaSBySubjectTemplateBeforeExpiredAt mocks base method
-func (m *MockPolicyManager) ListSaaSBySubjectTemplateBeforeExpiredAt(subjectType, subjectID string, templateID, expiredAt int64) ([]types.SaaSPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSaaSBySubjectTemplateBeforeExpiredAt", subjectType, subjectID, templateID, expiredAt)
-	ret0, _ := ret[0].([]types.SaaSPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSaaSBySubjectTemplateBeforeExpiredAt indicates an expected call of ListSaaSBySubjectTemplateBeforeExpiredAt
-func (mr *MockPolicyManagerMockRecorder) ListSaaSBySubjectTemplateBeforeExpiredAt(subjectType, subjectID, templateID, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSaaSBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListSaaSBySubjectTemplateBeforeExpiredAt), subjectType, subjectID, templateID, expiredAt)
-}
-
-// AlterCustomPolicies mocks base method
+// AlterCustomPolicies mocks base method.
 func (m *MockPolicyManager) AlterCustomPolicies(system, subjectType, subjectID string, createPolicies, updatePolicies []types.Policy, deletePolicyIDs []int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AlterCustomPolicies", system, subjectType, subjectID, createPolicies, updatePolicies, deletePolicyIDs)
@@ -103,70 +44,13 @@ func (m *MockPolicyManager) AlterCustomPolicies(system, subjectType, subjectID s
 	return ret0
 }
 
-// AlterCustomPolicies indicates an expected call of AlterCustomPolicies
+// AlterCustomPolicies indicates an expected call of AlterCustomPolicies.
 func (mr *MockPolicyManagerMockRecorder) AlterCustomPolicies(system, subjectType, subjectID, createPolicies, updatePolicies, deletePolicyIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlterCustomPolicies", reflect.TypeOf((*MockPolicyManager)(nil).AlterCustomPolicies), system, subjectType, subjectID, createPolicies, updatePolicies, deletePolicyIDs)
 }
 
-// UpdateSubjectPoliciesExpiredAt mocks base method
-func (m *MockPolicyManager) UpdateSubjectPoliciesExpiredAt(subjectType, subjectID string, policies []types.PolicyPKExpiredAt) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSubjectPoliciesExpiredAt", subjectType, subjectID, policies)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateSubjectPoliciesExpiredAt indicates an expected call of UpdateSubjectPoliciesExpiredAt
-func (mr *MockPolicyManagerMockRecorder) UpdateSubjectPoliciesExpiredAt(subjectType, subjectID, policies interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubjectPoliciesExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).UpdateSubjectPoliciesExpiredAt), subjectType, subjectID, policies)
-}
-
-// DeleteByIDs mocks base method
-func (m *MockPolicyManager) DeleteByIDs(system, subjectType, subjectID string, policyIDs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByIDs", system, subjectType, subjectID, policyIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByIDs indicates an expected call of DeleteByIDs
-func (mr *MockPolicyManagerMockRecorder) DeleteByIDs(system, subjectType, subjectID, policyIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByIDs", reflect.TypeOf((*MockPolicyManager)(nil).DeleteByIDs), system, subjectType, subjectID, policyIDs)
-}
-
-// GetExpressionsFromCache mocks base method
-func (m *MockPolicyManager) GetExpressionsFromCache(actionPK int64, expressionPKs []int64) ([]types0.AuthExpression, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExpressionsFromCache", actionPK, expressionPKs)
-	ret0, _ := ret[0].([]types0.AuthExpression)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetExpressionsFromCache indicates an expected call of GetExpressionsFromCache
-func (mr *MockPolicyManagerMockRecorder) GetExpressionsFromCache(actionPK, expressionPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExpressionsFromCache", reflect.TypeOf((*MockPolicyManager)(nil).GetExpressionsFromCache), actionPK, expressionPKs)
-}
-
-// DeleteByActionID mocks base method
-func (m *MockPolicyManager) DeleteByActionID(system, actionID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByActionID", system, actionID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByActionID indicates an expected call of DeleteByActionID
-func (mr *MockPolicyManagerMockRecorder) DeleteByActionID(system, actionID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByActionID", reflect.TypeOf((*MockPolicyManager)(nil).DeleteByActionID), system, actionID)
-}
-
-// CreateAndDeleteTemplatePolicies mocks base method
+// CreateAndDeleteTemplatePolicies mocks base method.
 func (m *MockPolicyManager) CreateAndDeleteTemplatePolicies(system, subjectType, subjectID string, templateID int64, createPolicies []types.Policy, deletePolicyIDs []int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAndDeleteTemplatePolicies", system, subjectType, subjectID, templateID, createPolicies, deletePolicyIDs)
@@ -174,41 +58,13 @@ func (m *MockPolicyManager) CreateAndDeleteTemplatePolicies(system, subjectType,
 	return ret0
 }
 
-// CreateAndDeleteTemplatePolicies indicates an expected call of CreateAndDeleteTemplatePolicies
+// CreateAndDeleteTemplatePolicies indicates an expected call of CreateAndDeleteTemplatePolicies.
 func (mr *MockPolicyManagerMockRecorder) CreateAndDeleteTemplatePolicies(system, subjectType, subjectID, templateID, createPolicies, deletePolicyIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndDeleteTemplatePolicies", reflect.TypeOf((*MockPolicyManager)(nil).CreateAndDeleteTemplatePolicies), system, subjectType, subjectID, templateID, createPolicies, deletePolicyIDs)
 }
 
-// UpdateTemplatePolicies mocks base method
-func (m *MockPolicyManager) UpdateTemplatePolicies(system, subjectType, subjectID string, policies []types.Policy) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTemplatePolicies", system, subjectType, subjectID, policies)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateTemplatePolicies indicates an expected call of UpdateTemplatePolicies
-func (mr *MockPolicyManagerMockRecorder) UpdateTemplatePolicies(system, subjectType, subjectID, policies interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplatePolicies", reflect.TypeOf((*MockPolicyManager)(nil).UpdateTemplatePolicies), system, subjectType, subjectID, policies)
-}
-
-// DeleteTemplatePolicies mocks base method
-func (m *MockPolicyManager) DeleteTemplatePolicies(system, subjectType, subjectID string, templateID int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplatePolicies", system, subjectType, subjectID, templateID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplatePolicies indicates an expected call of DeleteTemplatePolicies
-func (mr *MockPolicyManagerMockRecorder) DeleteTemplatePolicies(system, subjectType, subjectID, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplatePolicies", reflect.TypeOf((*MockPolicyManager)(nil).DeleteTemplatePolicies), system, subjectType, subjectID, templateID)
-}
-
-// CreateTemporaryPolicies mocks base method
+// CreateTemporaryPolicies mocks base method.
 func (m *MockPolicyManager) CreateTemporaryPolicies(system, subjectType, subjectID string, policies []types.Policy) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTemporaryPolicies", system, subjectType, subjectID, policies)
@@ -217,27 +73,55 @@ func (m *MockPolicyManager) CreateTemporaryPolicies(system, subjectType, subject
 	return ret0, ret1
 }
 
-// CreateTemporaryPolicies indicates an expected call of CreateTemporaryPolicies
+// CreateTemporaryPolicies indicates an expected call of CreateTemporaryPolicies.
 func (mr *MockPolicyManagerMockRecorder) CreateTemporaryPolicies(system, subjectType, subjectID, policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemporaryPolicies", reflect.TypeOf((*MockPolicyManager)(nil).CreateTemporaryPolicies), system, subjectType, subjectID, policies)
 }
 
-// DeleteTemporaryByIDs mocks base method
-func (m *MockPolicyManager) DeleteTemporaryByIDs(system, subjectType, subjectID string, policyIDs []int64) error {
+// DeleteByActionID mocks base method.
+func (m *MockPolicyManager) DeleteByActionID(system, actionID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemporaryByIDs", system, subjectType, subjectID, policyIDs)
+	ret := m.ctrl.Call(m, "DeleteByActionID", system, actionID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteTemporaryByIDs indicates an expected call of DeleteTemporaryByIDs
-func (mr *MockPolicyManagerMockRecorder) DeleteTemporaryByIDs(system, subjectType, subjectID, policyIDs interface{}) *gomock.Call {
+// DeleteByActionID indicates an expected call of DeleteByActionID.
+func (mr *MockPolicyManagerMockRecorder) DeleteByActionID(system, actionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemporaryByIDs", reflect.TypeOf((*MockPolicyManager)(nil).DeleteTemporaryByIDs), system, subjectType, subjectID, policyIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByActionID", reflect.TypeOf((*MockPolicyManager)(nil).DeleteByActionID), system, actionID)
 }
 
-// DeleteTemporaryBeforeExpiredAt mocks base method
+// DeleteByIDs mocks base method.
+func (m *MockPolicyManager) DeleteByIDs(system, subjectType, subjectID string, policyIDs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByIDs", system, subjectType, subjectID, policyIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByIDs indicates an expected call of DeleteByIDs.
+func (mr *MockPolicyManagerMockRecorder) DeleteByIDs(system, subjectType, subjectID, policyIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByIDs", reflect.TypeOf((*MockPolicyManager)(nil).DeleteByIDs), system, subjectType, subjectID, policyIDs)
+}
+
+// DeleteTemplatePolicies mocks base method.
+func (m *MockPolicyManager) DeleteTemplatePolicies(system, subjectType, subjectID string, templateID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplatePolicies", system, subjectType, subjectID, templateID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplatePolicies indicates an expected call of DeleteTemplatePolicies.
+func (mr *MockPolicyManagerMockRecorder) DeleteTemplatePolicies(system, subjectType, subjectID, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplatePolicies", reflect.TypeOf((*MockPolicyManager)(nil).DeleteTemplatePolicies), system, subjectType, subjectID, templateID)
+}
+
+// DeleteTemporaryBeforeExpiredAt mocks base method.
 func (m *MockPolicyManager) DeleteTemporaryBeforeExpiredAt(expiredAt int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTemporaryBeforeExpiredAt", expiredAt)
@@ -245,8 +129,125 @@ func (m *MockPolicyManager) DeleteTemporaryBeforeExpiredAt(expiredAt int64) erro
 	return ret0
 }
 
-// DeleteTemporaryBeforeExpiredAt indicates an expected call of DeleteTemporaryBeforeExpiredAt
+// DeleteTemporaryBeforeExpiredAt indicates an expected call of DeleteTemporaryBeforeExpiredAt.
 func (mr *MockPolicyManagerMockRecorder) DeleteTemporaryBeforeExpiredAt(expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemporaryBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).DeleteTemporaryBeforeExpiredAt), expiredAt)
+}
+
+// DeleteTemporaryByIDs mocks base method.
+func (m *MockPolicyManager) DeleteTemporaryByIDs(system, subjectType, subjectID string, policyIDs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemporaryByIDs", system, subjectType, subjectID, policyIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemporaryByIDs indicates an expected call of DeleteTemporaryByIDs.
+func (mr *MockPolicyManagerMockRecorder) DeleteTemporaryByIDs(system, subjectType, subjectID, policyIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemporaryByIDs", reflect.TypeOf((*MockPolicyManager)(nil).DeleteTemporaryByIDs), system, subjectType, subjectID, policyIDs)
+}
+
+// GetByActionTemplate mocks base method.
+func (m *MockPolicyManager) GetByActionTemplate(system, subjectType, subjectID, actionID string, templateID int64) (types.AuthPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByActionTemplate", system, subjectType, subjectID, actionID, templateID)
+	ret0, _ := ret[0].(types.AuthPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByActionTemplate indicates an expected call of GetByActionTemplate.
+func (mr *MockPolicyManagerMockRecorder) GetByActionTemplate(system, subjectType, subjectID, actionID, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).GetByActionTemplate), system, subjectType, subjectID, actionID, templateID)
+}
+
+// GetExpressionsFromCache mocks base method.
+func (m *MockPolicyManager) GetExpressionsFromCache(actionPK int64, expressionPKs []int64) ([]types0.AuthExpression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExpressionsFromCache", actionPK, expressionPKs)
+	ret0, _ := ret[0].([]types0.AuthExpression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExpressionsFromCache indicates an expected call of GetExpressionsFromCache.
+func (mr *MockPolicyManagerMockRecorder) GetExpressionsFromCache(actionPK, expressionPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExpressionsFromCache", reflect.TypeOf((*MockPolicyManager)(nil).GetExpressionsFromCache), actionPK, expressionPKs)
+}
+
+// ListBySubjectAction mocks base method.
+func (m *MockPolicyManager) ListBySubjectAction(system string, subject types.Subject, action types.Action, withoutCache bool, entry *debug.Entry) ([]types.AuthPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySubjectAction", system, subject, action, withoutCache, entry)
+	ret0, _ := ret[0].([]types.AuthPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySubjectAction indicates an expected call of ListBySubjectAction.
+func (mr *MockPolicyManagerMockRecorder) ListBySubjectAction(system, subject, action, withoutCache, entry interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectAction", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectAction), system, subject, action, withoutCache, entry)
+}
+
+// ListSaaSBySubjectSystemTemplate mocks base method.
+func (m *MockPolicyManager) ListSaaSBySubjectSystemTemplate(system, subjectType, subjectID string, templateID int64) ([]types.SaaSPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSaaSBySubjectSystemTemplate", system, subjectType, subjectID, templateID)
+	ret0, _ := ret[0].([]types.SaaSPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSaaSBySubjectSystemTemplate indicates an expected call of ListSaaSBySubjectSystemTemplate.
+func (mr *MockPolicyManagerMockRecorder) ListSaaSBySubjectSystemTemplate(system, subjectType, subjectID, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSaaSBySubjectSystemTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListSaaSBySubjectSystemTemplate), system, subjectType, subjectID, templateID)
+}
+
+// ListSaaSBySubjectTemplateBeforeExpiredAt mocks base method.
+func (m *MockPolicyManager) ListSaaSBySubjectTemplateBeforeExpiredAt(subjectType, subjectID string, templateID, expiredAt int64) ([]types.SaaSPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSaaSBySubjectTemplateBeforeExpiredAt", subjectType, subjectID, templateID, expiredAt)
+	ret0, _ := ret[0].([]types.SaaSPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSaaSBySubjectTemplateBeforeExpiredAt indicates an expected call of ListSaaSBySubjectTemplateBeforeExpiredAt.
+func (mr *MockPolicyManagerMockRecorder) ListSaaSBySubjectTemplateBeforeExpiredAt(subjectType, subjectID, templateID, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSaaSBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListSaaSBySubjectTemplateBeforeExpiredAt), subjectType, subjectID, templateID, expiredAt)
+}
+
+// UpdateSubjectPoliciesExpiredAt mocks base method.
+func (m *MockPolicyManager) UpdateSubjectPoliciesExpiredAt(subjectType, subjectID string, policies []types.PolicyPKExpiredAt) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubjectPoliciesExpiredAt", subjectType, subjectID, policies)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSubjectPoliciesExpiredAt indicates an expected call of UpdateSubjectPoliciesExpiredAt.
+func (mr *MockPolicyManagerMockRecorder) UpdateSubjectPoliciesExpiredAt(subjectType, subjectID, policies interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubjectPoliciesExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).UpdateSubjectPoliciesExpiredAt), subjectType, subjectID, policies)
+}
+
+// UpdateTemplatePolicies mocks base method.
+func (m *MockPolicyManager) UpdateTemplatePolicies(system, subjectType, subjectID string, policies []types.Policy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTemplatePolicies", system, subjectType, subjectID, policies)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateTemplatePolicies indicates an expected call of UpdateTemplatePolicies.
+func (mr *MockPolicyManagerMockRecorder) UpdateTemplatePolicies(system, subjectType, subjectID, policies interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplatePolicies", reflect.TypeOf((*MockPolicyManager)(nil).UpdateTemplatePolicies), system, subjectType, subjectID, policies)
 }

--- a/pkg/component/mock/auth.go
+++ b/pkg/component/mock/auth.go
@@ -5,34 +5,35 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockAuthClient is a mock of AuthClient interface
+// MockAuthClient is a mock of AuthClient interface.
 type MockAuthClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockAuthClientMockRecorder
 }
 
-// MockAuthClientMockRecorder is the mock recorder for MockAuthClient
+// MockAuthClientMockRecorder is the mock recorder for MockAuthClient.
 type MockAuthClientMockRecorder struct {
 	mock *MockAuthClient
 }
 
-// NewMockAuthClient creates a new mock instance
+// NewMockAuthClient creates a new mock instance.
 func NewMockAuthClient(ctrl *gomock.Controller) *MockAuthClient {
 	mock := &MockAuthClient{ctrl: ctrl}
 	mock.recorder = &MockAuthClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAuthClient) EXPECT() *MockAuthClientMockRecorder {
 	return m.recorder
 }
 
-// Verify mocks base method
+// Verify mocks base method.
 func (m *MockAuthClient) Verify(appCode, appSecret string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Verify", appCode, appSecret)
@@ -41,7 +42,7 @@ func (m *MockAuthClient) Verify(appCode, appSecret string) (bool, error) {
 	return ret0, ret1
 }
 
-// Verify indicates an expected call of Verify
+// Verify indicates an expected call of Verify.
 func (mr *MockAuthClientMockRecorder) Verify(appCode, appSecret interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockAuthClient)(nil).Verify), appCode, appSecret)

--- a/pkg/component/mock/remote_resource.go
+++ b/pkg/component/mock/remote_resource.go
@@ -5,50 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	component "iam/pkg/component"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRemoteResourceClient is a mock of RemoteResourceClient interface
+// MockRemoteResourceClient is a mock of RemoteResourceClient interface.
 type MockRemoteResourceClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteResourceClientMockRecorder
 }
 
-// MockRemoteResourceClientMockRecorder is the mock recorder for MockRemoteResourceClient
+// MockRemoteResourceClientMockRecorder is the mock recorder for MockRemoteResourceClient.
 type MockRemoteResourceClientMockRecorder struct {
 	mock *MockRemoteResourceClient
 }
 
-// NewMockRemoteResourceClient creates a new mock instance
+// NewMockRemoteResourceClient creates a new mock instance.
 func NewMockRemoteResourceClient(ctrl *gomock.Controller) *MockRemoteResourceClient {
 	mock := &MockRemoteResourceClient{ctrl: ctrl}
 	mock.recorder = &MockRemoteResourceClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteResourceClient) EXPECT() *MockRemoteResourceClientMockRecorder {
 	return m.recorder
 }
 
-// QueryResources mocks base method
-func (m *MockRemoteResourceClient) QueryResources(req component.RemoteResourceRequest, system, _type string, ids, fields []string) ([]map[string]interface{}, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryResources", req, system, _type, ids, fields)
-	ret0, _ := ret[0].([]map[string]interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// QueryResources indicates an expected call of QueryResources
-func (mr *MockRemoteResourceClientMockRecorder) QueryResources(req, system, _type, ids, fields interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryResources", reflect.TypeOf((*MockRemoteResourceClient)(nil).QueryResources), req, system, _type, ids, fields)
-}
-
-// GetResources mocks base method
+// GetResources mocks base method.
 func (m *MockRemoteResourceClient) GetResources(req component.RemoteResourceRequest, system, _type string, ids, fields []string) ([]map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResources", req, system, _type, ids, fields)
@@ -57,8 +43,23 @@ func (m *MockRemoteResourceClient) GetResources(req component.RemoteResourceRequ
 	return ret0, ret1
 }
 
-// GetResources indicates an expected call of GetResources
+// GetResources indicates an expected call of GetResources.
 func (mr *MockRemoteResourceClientMockRecorder) GetResources(req, system, _type, ids, fields interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*MockRemoteResourceClient)(nil).GetResources), req, system, _type, ids, fields)
+}
+
+// QueryResources mocks base method.
+func (m *MockRemoteResourceClient) QueryResources(req component.RemoteResourceRequest, system, _type string, ids, fields []string) ([]map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryResources", req, system, _type, ids, fields)
+	ret0, _ := ret[0].([]map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryResources indicates an expected call of QueryResources.
+func (mr *MockRemoteResourceClientMockRecorder) QueryResources(req, system, _type, ids, fields interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryResources", reflect.TypeOf((*MockRemoteResourceClient)(nil).QueryResources), req, system, _type, ids, fields)
 }

--- a/pkg/database/dao/mock/action.go
+++ b/pkg/database/dao/mock/action.go
@@ -5,51 +5,65 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockActionManager is a mock of ActionManager interface
+// MockActionManager is a mock of ActionManager interface.
 type MockActionManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockActionManagerMockRecorder
 }
 
-// MockActionManagerMockRecorder is the mock recorder for MockActionManager
+// MockActionManagerMockRecorder is the mock recorder for MockActionManager.
 type MockActionManagerMockRecorder struct {
 	mock *MockActionManager
 }
 
-// NewMockActionManager creates a new mock instance
+// NewMockActionManager creates a new mock instance.
 func NewMockActionManager(ctrl *gomock.Controller) *MockActionManager {
 	mock := &MockActionManager{ctrl: ctrl}
 	mock.recorder = &MockActionManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockActionManager) EXPECT() *MockActionManagerMockRecorder {
 	return m.recorder
 }
 
-// GetPK mocks base method
-func (m *MockActionManager) GetPK(system, id string) (int64, error) {
+// BulkCreateWithTx mocks base method.
+func (m *MockActionManager) BulkCreateWithTx(tx *sqlx.Tx, actions []dao.Action) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPK", system, id)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, actions)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetPK indicates an expected call of GetPK
-func (mr *MockActionManagerMockRecorder) GetPK(system, id interface{}) *gomock.Call {
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
+func (mr *MockActionManagerMockRecorder) BulkCreateWithTx(tx, actions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockActionManager)(nil).GetPK), system, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockActionManager)(nil).BulkCreateWithTx), tx, actions)
 }
 
-// Get mocks base method
+// BulkDeleteWithTx mocks base method.
+func (m *MockActionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockActionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockActionManager)(nil).BulkDeleteWithTx), tx, system, ids)
+}
+
+// Get mocks base method.
 func (m *MockActionManager) Get(pk int64) (dao.Action, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", pk)
@@ -58,13 +72,28 @@ func (m *MockActionManager) Get(pk int64) (dao.Action, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockActionManagerMockRecorder) Get(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockActionManager)(nil).Get), pk)
 }
 
-// ListByPKs mocks base method
+// GetPK mocks base method.
+func (m *MockActionManager) GetPK(system, id string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPK", system, id)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPK indicates an expected call of GetPK.
+func (mr *MockActionManagerMockRecorder) GetPK(system, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockActionManager)(nil).GetPK), system, id)
+}
+
+// ListByPKs mocks base method.
 func (m *MockActionManager) ListByPKs(pks []int64) ([]dao.Action, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByPKs", pks)
@@ -73,13 +102,13 @@ func (m *MockActionManager) ListByPKs(pks []int64) ([]dao.Action, error) {
 	return ret0, ret1
 }
 
-// ListByPKs indicates an expected call of ListByPKs
+// ListByPKs indicates an expected call of ListByPKs.
 func (mr *MockActionManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockActionManager)(nil).ListByPKs), pks)
 }
 
-// ListBySystem mocks base method
+// ListBySystem mocks base method.
 func (m *MockActionManager) ListBySystem(system string) ([]dao.Action, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBySystem", system)
@@ -88,36 +117,8 @@ func (m *MockActionManager) ListBySystem(system string) ([]dao.Action, error) {
 	return ret0, ret1
 }
 
-// ListBySystem indicates an expected call of ListBySystem
+// ListBySystem indicates an expected call of ListBySystem.
 func (mr *MockActionManagerMockRecorder) ListBySystem(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockActionManager)(nil).ListBySystem), system)
-}
-
-// BulkCreateWithTx mocks base method
-func (m *MockActionManager) BulkCreateWithTx(tx *sqlx.Tx, actions []dao.Action) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, actions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
-func (mr *MockActionManagerMockRecorder) BulkCreateWithTx(tx, actions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockActionManager)(nil).BulkCreateWithTx), tx, actions)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockActionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockActionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockActionManager)(nil).BulkDeleteWithTx), tx, system, ids)
 }

--- a/pkg/database/dao/mock/action_resource_type.go
+++ b/pkg/database/dao/mock/action_resource_type.go
@@ -5,36 +5,65 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockActionResourceTypeManager is a mock of ActionResourceTypeManager interface
+// MockActionResourceTypeManager is a mock of ActionResourceTypeManager interface.
 type MockActionResourceTypeManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockActionResourceTypeManagerMockRecorder
 }
 
-// MockActionResourceTypeManagerMockRecorder is the mock recorder for MockActionResourceTypeManager
+// MockActionResourceTypeManagerMockRecorder is the mock recorder for MockActionResourceTypeManager.
 type MockActionResourceTypeManagerMockRecorder struct {
 	mock *MockActionResourceTypeManager
 }
 
-// NewMockActionResourceTypeManager creates a new mock instance
+// NewMockActionResourceTypeManager creates a new mock instance.
 func NewMockActionResourceTypeManager(ctrl *gomock.Controller) *MockActionResourceTypeManager {
 	mock := &MockActionResourceTypeManager{ctrl: ctrl}
 	mock.recorder = &MockActionResourceTypeManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockActionResourceTypeManager) EXPECT() *MockActionResourceTypeManagerMockRecorder {
 	return m.recorder
 }
 
-// ListByActionSystem mocks base method
+// BulkCreateWithTx mocks base method.
+func (m *MockActionResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, actionResourceTypes []dao.ActionResourceType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, actionResourceTypes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
+func (mr *MockActionResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, actionResourceTypes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockActionResourceTypeManager)(nil).BulkCreateWithTx), tx, actionResourceTypes)
+}
+
+// BulkDeleteWithTx mocks base method.
+func (m *MockActionResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, actionSystem string, actionIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, actionSystem, actionIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockActionResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, actionSystem, actionIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockActionResourceTypeManager)(nil).BulkDeleteWithTx), tx, actionSystem, actionIDs)
+}
+
+// ListByActionSystem mocks base method.
 func (m *MockActionResourceTypeManager) ListByActionSystem(actionSystem string) ([]dao.ActionResourceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByActionSystem", actionSystem)
@@ -43,28 +72,13 @@ func (m *MockActionResourceTypeManager) ListByActionSystem(actionSystem string) 
 	return ret0, ret1
 }
 
-// ListByActionSystem indicates an expected call of ListByActionSystem
+// ListByActionSystem indicates an expected call of ListByActionSystem.
 func (mr *MockActionResourceTypeManagerMockRecorder) ListByActionSystem(actionSystem interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByActionSystem", reflect.TypeOf((*MockActionResourceTypeManager)(nil).ListByActionSystem), actionSystem)
 }
 
-// ListResourceTypeByAction mocks base method
-func (m *MockActionResourceTypeManager) ListResourceTypeByAction(actionSystem, actionID string) ([]dao.ActionResourceType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourceTypeByAction", actionSystem, actionID)
-	ret0, _ := ret[0].([]dao.ActionResourceType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListResourceTypeByAction indicates an expected call of ListResourceTypeByAction
-func (mr *MockActionResourceTypeManagerMockRecorder) ListResourceTypeByAction(actionSystem, actionID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceTypeByAction", reflect.TypeOf((*MockActionResourceTypeManager)(nil).ListResourceTypeByAction), actionSystem, actionID)
-}
-
-// ListByResourceTypeSystem mocks base method
+// ListByResourceTypeSystem mocks base method.
 func (m *MockActionResourceTypeManager) ListByResourceTypeSystem(resourceTypeSystem string) ([]dao.ActionResourceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByResourceTypeSystem", resourceTypeSystem)
@@ -73,36 +87,23 @@ func (m *MockActionResourceTypeManager) ListByResourceTypeSystem(resourceTypeSys
 	return ret0, ret1
 }
 
-// ListByResourceTypeSystem indicates an expected call of ListByResourceTypeSystem
+// ListByResourceTypeSystem indicates an expected call of ListByResourceTypeSystem.
 func (mr *MockActionResourceTypeManagerMockRecorder) ListByResourceTypeSystem(resourceTypeSystem interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByResourceTypeSystem", reflect.TypeOf((*MockActionResourceTypeManager)(nil).ListByResourceTypeSystem), resourceTypeSystem)
 }
 
-// BulkCreateWithTx mocks base method
-func (m *MockActionResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, actionResourceTypes []dao.ActionResourceType) error {
+// ListResourceTypeByAction mocks base method.
+func (m *MockActionResourceTypeManager) ListResourceTypeByAction(actionSystem, actionID string) ([]dao.ActionResourceType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, actionResourceTypes)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ListResourceTypeByAction", actionSystem, actionID)
+	ret0, _ := ret[0].([]dao.ActionResourceType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
-func (mr *MockActionResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, actionResourceTypes interface{}) *gomock.Call {
+// ListResourceTypeByAction indicates an expected call of ListResourceTypeByAction.
+func (mr *MockActionResourceTypeManagerMockRecorder) ListResourceTypeByAction(actionSystem, actionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockActionResourceTypeManager)(nil).BulkCreateWithTx), tx, actionResourceTypes)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockActionResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, actionSystem string, actionIDs []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, actionSystem, actionIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockActionResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, actionSystem, actionIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockActionResourceTypeManager)(nil).BulkDeleteWithTx), tx, actionSystem, actionIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceTypeByAction", reflect.TypeOf((*MockActionResourceTypeManager)(nil).ListResourceTypeByAction), actionSystem, actionID)
 }

--- a/pkg/database/dao/mock/engine_policy.go
+++ b/pkg/database/dao/mock/engine_policy.go
@@ -5,65 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEnginePolicyManager is a mock of EnginePolicyManager interface
+// MockEnginePolicyManager is a mock of EnginePolicyManager interface.
 type MockEnginePolicyManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnginePolicyManagerMockRecorder
 }
 
-// MockEnginePolicyManagerMockRecorder is the mock recorder for MockEnginePolicyManager
+// MockEnginePolicyManagerMockRecorder is the mock recorder for MockEnginePolicyManager.
 type MockEnginePolicyManagerMockRecorder struct {
 	mock *MockEnginePolicyManager
 }
 
-// NewMockEnginePolicyManager creates a new mock instance
+// NewMockEnginePolicyManager creates a new mock instance.
 func NewMockEnginePolicyManager(ctrl *gomock.Controller) *MockEnginePolicyManager {
 	mock := &MockEnginePolicyManager{ctrl: ctrl}
 	mock.recorder = &MockEnginePolicyManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnginePolicyManager) EXPECT() *MockEnginePolicyManagerMockRecorder {
 	return m.recorder
 }
 
-// ListBetweenPK mocks base method
-func (m *MockEnginePolicyManager) ListBetweenPK(expiredAt, minPK, maxPK int64) ([]dao.EnginePolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBetweenPK", expiredAt, minPK, maxPK)
-	ret0, _ := ret[0].([]dao.EnginePolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBetweenPK indicates an expected call of ListBetweenPK
-func (mr *MockEnginePolicyManagerMockRecorder) ListBetweenPK(expiredAt, minPK, maxPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBetweenPK", reflect.TypeOf((*MockEnginePolicyManager)(nil).ListBetweenPK), expiredAt, minPK, maxPK)
-}
-
-// ListByPKs mocks base method
-func (m *MockEnginePolicyManager) ListByPKs(pks []int64) ([]dao.EnginePolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByPKs", pks)
-	ret0, _ := ret[0].([]dao.EnginePolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByPKs indicates an expected call of ListByPKs
-func (mr *MockEnginePolicyManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockEnginePolicyManager)(nil).ListByPKs), pks)
-}
-
-// GetMaxPKBeforeUpdatedAt mocks base method
+// GetMaxPKBeforeUpdatedAt mocks base method.
 func (m *MockEnginePolicyManager) GetMaxPKBeforeUpdatedAt(updatedAt int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaxPKBeforeUpdatedAt", updatedAt)
@@ -72,13 +43,43 @@ func (m *MockEnginePolicyManager) GetMaxPKBeforeUpdatedAt(updatedAt int64) (int6
 	return ret0, ret1
 }
 
-// GetMaxPKBeforeUpdatedAt indicates an expected call of GetMaxPKBeforeUpdatedAt
+// GetMaxPKBeforeUpdatedAt indicates an expected call of GetMaxPKBeforeUpdatedAt.
 func (mr *MockEnginePolicyManagerMockRecorder) GetMaxPKBeforeUpdatedAt(updatedAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxPKBeforeUpdatedAt", reflect.TypeOf((*MockEnginePolicyManager)(nil).GetMaxPKBeforeUpdatedAt), updatedAt)
 }
 
-// ListPKBetweenUpdatedAt mocks base method
+// ListBetweenPK mocks base method.
+func (m *MockEnginePolicyManager) ListBetweenPK(expiredAt, minPK, maxPK int64) ([]dao.EnginePolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBetweenPK", expiredAt, minPK, maxPK)
+	ret0, _ := ret[0].([]dao.EnginePolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBetweenPK indicates an expected call of ListBetweenPK.
+func (mr *MockEnginePolicyManagerMockRecorder) ListBetweenPK(expiredAt, minPK, maxPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBetweenPK", reflect.TypeOf((*MockEnginePolicyManager)(nil).ListBetweenPK), expiredAt, minPK, maxPK)
+}
+
+// ListByPKs mocks base method.
+func (m *MockEnginePolicyManager) ListByPKs(pks []int64) ([]dao.EnginePolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByPKs", pks)
+	ret0, _ := ret[0].([]dao.EnginePolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByPKs indicates an expected call of ListByPKs.
+func (mr *MockEnginePolicyManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockEnginePolicyManager)(nil).ListByPKs), pks)
+}
+
+// ListPKBetweenUpdatedAt mocks base method.
 func (m *MockEnginePolicyManager) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt int64) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPKBetweenUpdatedAt", beginUpdatedAt, endUpdatedAt)
@@ -87,7 +88,7 @@ func (m *MockEnginePolicyManager) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpda
 	return ret0, ret1
 }
 
-// ListPKBetweenUpdatedAt indicates an expected call of ListPKBetweenUpdatedAt
+// ListPKBetweenUpdatedAt indicates an expected call of ListPKBetweenUpdatedAt.
 func (mr *MockEnginePolicyManagerMockRecorder) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPKBetweenUpdatedAt", reflect.TypeOf((*MockEnginePolicyManager)(nil).ListPKBetweenUpdatedAt), beginUpdatedAt, endUpdatedAt)

--- a/pkg/database/dao/mock/expression.go
+++ b/pkg/database/dao/mock/expression.go
@@ -5,66 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockExpressionManager is a mock of ExpressionManager interface
+// MockExpressionManager is a mock of ExpressionManager interface.
 type MockExpressionManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockExpressionManagerMockRecorder
 }
 
-// MockExpressionManagerMockRecorder is the mock recorder for MockExpressionManager
+// MockExpressionManagerMockRecorder is the mock recorder for MockExpressionManager.
 type MockExpressionManagerMockRecorder struct {
 	mock *MockExpressionManager
 }
 
-// NewMockExpressionManager creates a new mock instance
+// NewMockExpressionManager creates a new mock instance.
 func NewMockExpressionManager(ctrl *gomock.Controller) *MockExpressionManager {
 	mock := &MockExpressionManager{ctrl: ctrl}
 	mock.recorder = &MockExpressionManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExpressionManager) EXPECT() *MockExpressionManagerMockRecorder {
 	return m.recorder
 }
 
-// ListAuthByPKs mocks base method
-func (m *MockExpressionManager) ListAuthByPKs(pks []int64) ([]dao.AuthExpression, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuthByPKs", pks)
-	ret0, _ := ret[0].([]dao.AuthExpression)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAuthByPKs indicates an expected call of ListAuthByPKs
-func (mr *MockExpressionManagerMockRecorder) ListAuthByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthByPKs", reflect.TypeOf((*MockExpressionManager)(nil).ListAuthByPKs), pks)
-}
-
-// ListDistinctBySignaturesType mocks base method
-func (m *MockExpressionManager) ListDistinctBySignaturesType(signatures []string, _type int64) ([]dao.Expression, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDistinctBySignaturesType", signatures, _type)
-	ret0, _ := ret[0].([]dao.Expression)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDistinctBySignaturesType indicates an expected call of ListDistinctBySignaturesType
-func (mr *MockExpressionManagerMockRecorder) ListDistinctBySignaturesType(signatures, _type interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDistinctBySignaturesType", reflect.TypeOf((*MockExpressionManager)(nil).ListDistinctBySignaturesType), signatures, _type)
-}
-
-// BulkCreateWithTx mocks base method
+// BulkCreateWithTx mocks base method.
 func (m *MockExpressionManager) BulkCreateWithTx(tx *sqlx.Tx, expressions []dao.Expression) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, expressions)
@@ -73,27 +44,13 @@ func (m *MockExpressionManager) BulkCreateWithTx(tx *sqlx.Tx, expressions []dao.
 	return ret0, ret1
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
 func (mr *MockExpressionManagerMockRecorder) BulkCreateWithTx(tx, expressions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockExpressionManager)(nil).BulkCreateWithTx), tx, expressions)
 }
 
-// BulkUpdateWithTx mocks base method
-func (m *MockExpressionManager) BulkUpdateWithTx(tx *sqlx.Tx, expressions []dao.Expression) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdateWithTx", tx, expressions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkUpdateWithTx indicates an expected call of BulkUpdateWithTx
-func (mr *MockExpressionManagerMockRecorder) BulkUpdateWithTx(tx, expressions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateWithTx", reflect.TypeOf((*MockExpressionManager)(nil).BulkUpdateWithTx), tx, expressions)
-}
-
-// BulkDeleteByPKsWithTx mocks base method
+// BulkDeleteByPKsWithTx mocks base method.
 func (m *MockExpressionManager) BulkDeleteByPKsWithTx(tx *sqlx.Tx, pks []int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteByPKsWithTx", tx, pks)
@@ -102,27 +59,27 @@ func (m *MockExpressionManager) BulkDeleteByPKsWithTx(tx *sqlx.Tx, pks []int64) 
 	return ret0, ret1
 }
 
-// BulkDeleteByPKsWithTx indicates an expected call of BulkDeleteByPKsWithTx
+// BulkDeleteByPKsWithTx indicates an expected call of BulkDeleteByPKsWithTx.
 func (mr *MockExpressionManagerMockRecorder) BulkDeleteByPKsWithTx(tx, pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByPKsWithTx", reflect.TypeOf((*MockExpressionManager)(nil).BulkDeleteByPKsWithTx), tx, pks)
 }
 
-// ChangeUnreferencedExpressionType mocks base method
-func (m *MockExpressionManager) ChangeUnreferencedExpressionType(fromType, toType int64) error {
+// BulkUpdateWithTx mocks base method.
+func (m *MockExpressionManager) BulkUpdateWithTx(tx *sqlx.Tx, expressions []dao.Expression) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeUnreferencedExpressionType", fromType, toType)
+	ret := m.ctrl.Call(m, "BulkUpdateWithTx", tx, expressions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ChangeUnreferencedExpressionType indicates an expected call of ChangeUnreferencedExpressionType
-func (mr *MockExpressionManagerMockRecorder) ChangeUnreferencedExpressionType(fromType, toType interface{}) *gomock.Call {
+// BulkUpdateWithTx indicates an expected call of BulkUpdateWithTx.
+func (mr *MockExpressionManagerMockRecorder) BulkUpdateWithTx(tx, expressions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeUnreferencedExpressionType", reflect.TypeOf((*MockExpressionManager)(nil).ChangeUnreferencedExpressionType), fromType, toType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateWithTx", reflect.TypeOf((*MockExpressionManager)(nil).BulkUpdateWithTx), tx, expressions)
 }
 
-// ChangeReferencedExpressionTypeBeforeUpdateAt mocks base method
+// ChangeReferencedExpressionTypeBeforeUpdateAt mocks base method.
 func (m *MockExpressionManager) ChangeReferencedExpressionTypeBeforeUpdateAt(fromType, toType, updatedAt int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeReferencedExpressionTypeBeforeUpdateAt", fromType, toType, updatedAt)
@@ -130,13 +87,27 @@ func (m *MockExpressionManager) ChangeReferencedExpressionTypeBeforeUpdateAt(fro
 	return ret0
 }
 
-// ChangeReferencedExpressionTypeBeforeUpdateAt indicates an expected call of ChangeReferencedExpressionTypeBeforeUpdateAt
+// ChangeReferencedExpressionTypeBeforeUpdateAt indicates an expected call of ChangeReferencedExpressionTypeBeforeUpdateAt.
 func (mr *MockExpressionManagerMockRecorder) ChangeReferencedExpressionTypeBeforeUpdateAt(fromType, toType, updatedAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeReferencedExpressionTypeBeforeUpdateAt", reflect.TypeOf((*MockExpressionManager)(nil).ChangeReferencedExpressionTypeBeforeUpdateAt), fromType, toType, updatedAt)
 }
 
-// DeleteUnreferencedExpressionByTypeBeforeUpdateAt mocks base method
+// ChangeUnreferencedExpressionType mocks base method.
+func (m *MockExpressionManager) ChangeUnreferencedExpressionType(fromType, toType int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeUnreferencedExpressionType", fromType, toType)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChangeUnreferencedExpressionType indicates an expected call of ChangeUnreferencedExpressionType.
+func (mr *MockExpressionManagerMockRecorder) ChangeUnreferencedExpressionType(fromType, toType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeUnreferencedExpressionType", reflect.TypeOf((*MockExpressionManager)(nil).ChangeUnreferencedExpressionType), fromType, toType)
+}
+
+// DeleteUnreferencedExpressionByTypeBeforeUpdateAt mocks base method.
 func (m *MockExpressionManager) DeleteUnreferencedExpressionByTypeBeforeUpdateAt(_type, updatedAt int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUnreferencedExpressionByTypeBeforeUpdateAt", _type, updatedAt)
@@ -144,8 +115,38 @@ func (m *MockExpressionManager) DeleteUnreferencedExpressionByTypeBeforeUpdateAt
 	return ret0
 }
 
-// DeleteUnreferencedExpressionByTypeBeforeUpdateAt indicates an expected call of DeleteUnreferencedExpressionByTypeBeforeUpdateAt
+// DeleteUnreferencedExpressionByTypeBeforeUpdateAt indicates an expected call of DeleteUnreferencedExpressionByTypeBeforeUpdateAt.
 func (mr *MockExpressionManagerMockRecorder) DeleteUnreferencedExpressionByTypeBeforeUpdateAt(_type, updatedAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnreferencedExpressionByTypeBeforeUpdateAt", reflect.TypeOf((*MockExpressionManager)(nil).DeleteUnreferencedExpressionByTypeBeforeUpdateAt), _type, updatedAt)
+}
+
+// ListAuthByPKs mocks base method.
+func (m *MockExpressionManager) ListAuthByPKs(pks []int64) ([]dao.AuthExpression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAuthByPKs", pks)
+	ret0, _ := ret[0].([]dao.AuthExpression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAuthByPKs indicates an expected call of ListAuthByPKs.
+func (mr *MockExpressionManagerMockRecorder) ListAuthByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthByPKs", reflect.TypeOf((*MockExpressionManager)(nil).ListAuthByPKs), pks)
+}
+
+// ListDistinctBySignaturesType mocks base method.
+func (m *MockExpressionManager) ListDistinctBySignaturesType(signatures []string, _type int64) ([]dao.Expression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDistinctBySignaturesType", signatures, _type)
+	ret0, _ := ret[0].([]dao.Expression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDistinctBySignaturesType indicates an expected call of ListDistinctBySignaturesType.
+func (mr *MockExpressionManagerMockRecorder) ListDistinctBySignaturesType(signatures, _type interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDistinctBySignaturesType", reflect.TypeOf((*MockExpressionManager)(nil).ListDistinctBySignaturesType), signatures, _type)
 }

--- a/pkg/database/dao/mock/model_change_event.go
+++ b/pkg/database/dao/mock/model_change_event.go
@@ -5,80 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockModelChangeEventManager is a mock of ModelChangeEventManager interface
+// MockModelChangeEventManager is a mock of ModelChangeEventManager interface.
 type MockModelChangeEventManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelChangeEventManagerMockRecorder
 }
 
-// MockModelChangeEventManagerMockRecorder is the mock recorder for MockModelChangeEventManager
+// MockModelChangeEventManagerMockRecorder is the mock recorder for MockModelChangeEventManager.
 type MockModelChangeEventManagerMockRecorder struct {
 	mock *MockModelChangeEventManager
 }
 
-// NewMockModelChangeEventManager creates a new mock instance
+// NewMockModelChangeEventManager creates a new mock instance.
 func NewMockModelChangeEventManager(ctrl *gomock.Controller) *MockModelChangeEventManager {
 	mock := &MockModelChangeEventManager{ctrl: ctrl}
 	mock.recorder = &MockModelChangeEventManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelChangeEventManager) EXPECT() *MockModelChangeEventManagerMockRecorder {
 	return m.recorder
 }
 
-// GetByTypeModel mocks base method
-func (m *MockModelChangeEventManager) GetByTypeModel(eventType, status, modelType string, modelPK int64) (dao.ModelChangeEvent, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByTypeModel", eventType, status, modelType, modelPK)
-	ret0, _ := ret[0].(dao.ModelChangeEvent)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByTypeModel indicates an expected call of GetByTypeModel
-func (mr *MockModelChangeEventManagerMockRecorder) GetByTypeModel(eventType, status, modelType, modelPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByTypeModel", reflect.TypeOf((*MockModelChangeEventManager)(nil).GetByTypeModel), eventType, status, modelType, modelPK)
-}
-
-// ListByStatus mocks base method
-func (m *MockModelChangeEventManager) ListByStatus(status string, limit int64) ([]dao.ModelChangeEvent, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByStatus", status, limit)
-	ret0, _ := ret[0].([]dao.ModelChangeEvent)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByStatus indicates an expected call of ListByStatus
-func (mr *MockModelChangeEventManagerMockRecorder) ListByStatus(status, limit interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByStatus", reflect.TypeOf((*MockModelChangeEventManager)(nil).ListByStatus), status, limit)
-}
-
-// UpdateStatusByPK mocks base method
-func (m *MockModelChangeEventManager) UpdateStatusByPK(pk int64, status string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusByPK", pk, status)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateStatusByPK indicates an expected call of UpdateStatusByPK
-func (mr *MockModelChangeEventManagerMockRecorder) UpdateStatusByPK(pk, status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByPK", reflect.TypeOf((*MockModelChangeEventManager)(nil).UpdateStatusByPK), pk, status)
-}
-
-// BulkCreate mocks base method
+// BulkCreate mocks base method.
 func (m *MockModelChangeEventManager) BulkCreate(modelChangeEvents []dao.ModelChangeEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreate", modelChangeEvents)
@@ -86,27 +43,13 @@ func (m *MockModelChangeEventManager) BulkCreate(modelChangeEvents []dao.ModelCh
 	return ret0
 }
 
-// BulkCreate indicates an expected call of BulkCreate
+// BulkCreate indicates an expected call of BulkCreate.
 func (mr *MockModelChangeEventManagerMockRecorder) BulkCreate(modelChangeEvents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockModelChangeEventManager)(nil).BulkCreate), modelChangeEvents)
 }
 
-// UpdateStatusByModel mocks base method
-func (m *MockModelChangeEventManager) UpdateStatusByModel(eventType, modelType string, modelPK int64, status string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusByModel", eventType, modelType, modelPK, status)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateStatusByModel indicates an expected call of UpdateStatusByModel
-func (mr *MockModelChangeEventManagerMockRecorder) UpdateStatusByModel(eventType, modelType, modelPK, status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByModel", reflect.TypeOf((*MockModelChangeEventManager)(nil).UpdateStatusByModel), eventType, modelType, modelPK, status)
-}
-
-// DeleteByStatusWithTx mocks base method
+// DeleteByStatusWithTx mocks base method.
 func (m *MockModelChangeEventManager) DeleteByStatusWithTx(tx *sqlx.Tx, status string, beforeUpdatedAt, limit int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteByStatusWithTx", tx, status, beforeUpdatedAt, limit)
@@ -115,8 +58,66 @@ func (m *MockModelChangeEventManager) DeleteByStatusWithTx(tx *sqlx.Tx, status s
 	return ret0, ret1
 }
 
-// DeleteByStatusWithTx indicates an expected call of DeleteByStatusWithTx
+// DeleteByStatusWithTx indicates an expected call of DeleteByStatusWithTx.
 func (mr *MockModelChangeEventManagerMockRecorder) DeleteByStatusWithTx(tx, status, beforeUpdatedAt, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByStatusWithTx", reflect.TypeOf((*MockModelChangeEventManager)(nil).DeleteByStatusWithTx), tx, status, beforeUpdatedAt, limit)
+}
+
+// GetByTypeModel mocks base method.
+func (m *MockModelChangeEventManager) GetByTypeModel(eventType, status, modelType string, modelPK int64) (dao.ModelChangeEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByTypeModel", eventType, status, modelType, modelPK)
+	ret0, _ := ret[0].(dao.ModelChangeEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByTypeModel indicates an expected call of GetByTypeModel.
+func (mr *MockModelChangeEventManagerMockRecorder) GetByTypeModel(eventType, status, modelType, modelPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByTypeModel", reflect.TypeOf((*MockModelChangeEventManager)(nil).GetByTypeModel), eventType, status, modelType, modelPK)
+}
+
+// ListByStatus mocks base method.
+func (m *MockModelChangeEventManager) ListByStatus(status string, limit int64) ([]dao.ModelChangeEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByStatus", status, limit)
+	ret0, _ := ret[0].([]dao.ModelChangeEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByStatus indicates an expected call of ListByStatus.
+func (mr *MockModelChangeEventManagerMockRecorder) ListByStatus(status, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByStatus", reflect.TypeOf((*MockModelChangeEventManager)(nil).ListByStatus), status, limit)
+}
+
+// UpdateStatusByModel mocks base method.
+func (m *MockModelChangeEventManager) UpdateStatusByModel(eventType, modelType string, modelPK int64, status string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatusByModel", eventType, modelType, modelPK, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStatusByModel indicates an expected call of UpdateStatusByModel.
+func (mr *MockModelChangeEventManagerMockRecorder) UpdateStatusByModel(eventType, modelType, modelPK, status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByModel", reflect.TypeOf((*MockModelChangeEventManager)(nil).UpdateStatusByModel), eventType, modelType, modelPK, status)
+}
+
+// UpdateStatusByPK mocks base method.
+func (m *MockModelChangeEventManager) UpdateStatusByPK(pk int64, status string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatusByPK", pk, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStatusByPK indicates an expected call of UpdateStatusByPK.
+func (mr *MockModelChangeEventManagerMockRecorder) UpdateStatusByPK(pk, status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByPK", reflect.TypeOf((*MockModelChangeEventManager)(nil).UpdateStatusByPK), pk, status)
 }

--- a/pkg/database/dao/mock/policy.go
+++ b/pkg/database/dao/mock/policy.go
@@ -5,126 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockPolicyManager is a mock of PolicyManager interface
+// MockPolicyManager is a mock of PolicyManager interface.
 type MockPolicyManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockPolicyManagerMockRecorder
 }
 
-// MockPolicyManagerMockRecorder is the mock recorder for MockPolicyManager
+// MockPolicyManagerMockRecorder is the mock recorder for MockPolicyManager.
 type MockPolicyManagerMockRecorder struct {
 	mock *MockPolicyManager
 }
 
-// NewMockPolicyManager creates a new mock instance
+// NewMockPolicyManager creates a new mock instance.
 func NewMockPolicyManager(ctrl *gomock.Controller) *MockPolicyManager {
 	mock := &MockPolicyManager{ctrl: ctrl}
 	mock.recorder = &MockPolicyManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPolicyManager) EXPECT() *MockPolicyManagerMockRecorder {
 	return m.recorder
 }
 
-// ListAuthBySubjectAction mocks base method
-func (m *MockPolicyManager) ListAuthBySubjectAction(subjectPKs []int64, actionPK, expiredAt int64) ([]dao.AuthPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuthBySubjectAction", subjectPKs, actionPK, expiredAt)
-	ret0, _ := ret[0].([]dao.AuthPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAuthBySubjectAction indicates an expected call of ListAuthBySubjectAction
-func (mr *MockPolicyManagerMockRecorder) ListAuthBySubjectAction(subjectPKs, actionPK, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthBySubjectAction", reflect.TypeOf((*MockPolicyManager)(nil).ListAuthBySubjectAction), subjectPKs, actionPK, expiredAt)
-}
-
-// GetByActionTemplate mocks base method
-func (m *MockPolicyManager) GetByActionTemplate(subjectPK, actionPK, templateID int64) (dao.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByActionTemplate", subjectPK, actionPK, templateID)
-	ret0, _ := ret[0].(dao.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByActionTemplate indicates an expected call of GetByActionTemplate
-func (mr *MockPolicyManagerMockRecorder) GetByActionTemplate(subjectPK, actionPK, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).GetByActionTemplate), subjectPK, actionPK, templateID)
-}
-
-// ListBySubjectPKAndPKs mocks base method
-func (m *MockPolicyManager) ListBySubjectPKAndPKs(subjectPK int64, pks []int64) ([]dao.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySubjectPKAndPKs", subjectPK, pks)
-	ret0, _ := ret[0].([]dao.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySubjectPKAndPKs indicates an expected call of ListBySubjectPKAndPKs
-func (mr *MockPolicyManagerMockRecorder) ListBySubjectPKAndPKs(subjectPK, pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectPKAndPKs", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectPKAndPKs), subjectPK, pks)
-}
-
-// ListBySubjectActionTemplate mocks base method
-func (m *MockPolicyManager) ListBySubjectActionTemplate(subjectPK int64, actionPKs []int64, templateID int64) ([]dao.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySubjectActionTemplate", subjectPK, actionPKs, templateID)
-	ret0, _ := ret[0].([]dao.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySubjectActionTemplate indicates an expected call of ListBySubjectActionTemplate
-func (mr *MockPolicyManagerMockRecorder) ListBySubjectActionTemplate(subjectPK, actionPKs, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectActionTemplate), subjectPK, actionPKs, templateID)
-}
-
-// ListExpressionBySubjectsTemplate mocks base method
-func (m *MockPolicyManager) ListExpressionBySubjectsTemplate(subjectPKs []int64, templateID int64) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExpressionBySubjectsTemplate", subjectPKs, templateID)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListExpressionBySubjectsTemplate indicates an expected call of ListExpressionBySubjectsTemplate
-func (mr *MockPolicyManagerMockRecorder) ListExpressionBySubjectsTemplate(subjectPKs, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpressionBySubjectsTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListExpressionBySubjectsTemplate), subjectPKs, templateID)
-}
-
-// ListBySubjectTemplateBeforeExpiredAt mocks base method
-func (m *MockPolicyManager) ListBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt int64) ([]dao.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySubjectTemplateBeforeExpiredAt", subjectPK, templateID, expiredAt)
-	ret0, _ := ret[0].([]dao.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySubjectTemplateBeforeExpiredAt indicates an expected call of ListBySubjectTemplateBeforeExpiredAt
-func (mr *MockPolicyManagerMockRecorder) ListBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectTemplateBeforeExpiredAt), subjectPK, templateID, expiredAt)
-}
-
-// BulkCreateWithTx mocks base method
+// BulkCreateWithTx mocks base method.
 func (m *MockPolicyManager) BulkCreateWithTx(tx *sqlx.Tx, policies []dao.Policy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, policies)
@@ -132,13 +43,41 @@ func (m *MockPolicyManager) BulkCreateWithTx(tx *sqlx.Tx, policies []dao.Policy)
 	return ret0
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
 func (mr *MockPolicyManagerMockRecorder) BulkCreateWithTx(tx, policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkCreateWithTx), tx, policies)
 }
 
-// BulkDeleteByTemplatePKsWithTx mocks base method
+// BulkDeleteBySubjectPKsWithTx mocks base method.
+func (m *MockPolicyManager) BulkDeleteBySubjectPKsWithTx(tx *sqlx.Tx, subjectPKs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteBySubjectPKsWithTx", tx, subjectPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteBySubjectPKsWithTx indicates an expected call of BulkDeleteBySubjectPKsWithTx.
+func (mr *MockPolicyManagerMockRecorder) BulkDeleteBySubjectPKsWithTx(tx, subjectPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectPKsWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkDeleteBySubjectPKsWithTx), tx, subjectPKs)
+}
+
+// BulkDeleteBySubjectTemplate mocks base method.
+func (m *MockPolicyManager) BulkDeleteBySubjectTemplate(subjectPK, templateID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteBySubjectTemplate", subjectPK, templateID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteBySubjectTemplate indicates an expected call of BulkDeleteBySubjectTemplate.
+func (mr *MockPolicyManagerMockRecorder) BulkDeleteBySubjectTemplate(subjectPK, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectTemplate", reflect.TypeOf((*MockPolicyManager)(nil).BulkDeleteBySubjectTemplate), subjectPK, templateID)
+}
+
+// BulkDeleteByTemplatePKsWithTx mocks base method.
 func (m *MockPolicyManager) BulkDeleteByTemplatePKsWithTx(tx *sqlx.Tx, subjectPK, templateID int64, pks []int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteByTemplatePKsWithTx", tx, subjectPK, templateID, pks)
@@ -147,55 +86,13 @@ func (m *MockPolicyManager) BulkDeleteByTemplatePKsWithTx(tx *sqlx.Tx, subjectPK
 	return ret0, ret1
 }
 
-// BulkDeleteByTemplatePKsWithTx indicates an expected call of BulkDeleteByTemplatePKsWithTx
+// BulkDeleteByTemplatePKsWithTx indicates an expected call of BulkDeleteByTemplatePKsWithTx.
 func (mr *MockPolicyManagerMockRecorder) BulkDeleteByTemplatePKsWithTx(tx, subjectPK, templateID, pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByTemplatePKsWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkDeleteByTemplatePKsWithTx), tx, subjectPK, templateID, pks)
 }
 
-// BulkDeleteBySubjectPKsWithTx mocks base method
-func (m *MockPolicyManager) BulkDeleteBySubjectPKsWithTx(tx *sqlx.Tx, subjectPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteBySubjectPKsWithTx", tx, subjectPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteBySubjectPKsWithTx indicates an expected call of BulkDeleteBySubjectPKsWithTx
-func (mr *MockPolicyManagerMockRecorder) BulkDeleteBySubjectPKsWithTx(tx, subjectPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectPKsWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkDeleteBySubjectPKsWithTx), tx, subjectPKs)
-}
-
-// BulkUpdateExpressionPKWithTx mocks base method
-func (m *MockPolicyManager) BulkUpdateExpressionPKWithTx(tx *sqlx.Tx, policies []dao.Policy) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdateExpressionPKWithTx", tx, policies)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkUpdateExpressionPKWithTx indicates an expected call of BulkUpdateExpressionPKWithTx
-func (mr *MockPolicyManagerMockRecorder) BulkUpdateExpressionPKWithTx(tx, policies interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateExpressionPKWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkUpdateExpressionPKWithTx), tx, policies)
-}
-
-// BulkDeleteBySubjectTemplate mocks base method
-func (m *MockPolicyManager) BulkDeleteBySubjectTemplate(subjectPK, templateID int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteBySubjectTemplate", subjectPK, templateID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteBySubjectTemplate indicates an expected call of BulkDeleteBySubjectTemplate
-func (mr *MockPolicyManagerMockRecorder) BulkDeleteBySubjectTemplate(subjectPK, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectTemplate", reflect.TypeOf((*MockPolicyManager)(nil).BulkDeleteBySubjectTemplate), subjectPK, templateID)
-}
-
-// BulkUpdateExpiredAtWithTx mocks base method
+// BulkUpdateExpiredAtWithTx mocks base method.
 func (m *MockPolicyManager) BulkUpdateExpiredAtWithTx(tx *sqlx.Tx, policies []dao.Policy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkUpdateExpiredAtWithTx", tx, policies)
@@ -203,13 +100,27 @@ func (m *MockPolicyManager) BulkUpdateExpiredAtWithTx(tx *sqlx.Tx, policies []da
 	return ret0
 }
 
-// BulkUpdateExpiredAtWithTx indicates an expected call of BulkUpdateExpiredAtWithTx
+// BulkUpdateExpiredAtWithTx indicates an expected call of BulkUpdateExpiredAtWithTx.
 func (mr *MockPolicyManagerMockRecorder) BulkUpdateExpiredAtWithTx(tx, policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateExpiredAtWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkUpdateExpiredAtWithTx), tx, policies)
 }
 
-// DeleteByActionPKWithTx mocks base method
+// BulkUpdateExpressionPKWithTx mocks base method.
+func (m *MockPolicyManager) BulkUpdateExpressionPKWithTx(tx *sqlx.Tx, policies []dao.Policy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdateExpressionPKWithTx", tx, policies)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkUpdateExpressionPKWithTx indicates an expected call of BulkUpdateExpressionPKWithTx.
+func (mr *MockPolicyManagerMockRecorder) BulkUpdateExpressionPKWithTx(tx, policies interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateExpressionPKWithTx", reflect.TypeOf((*MockPolicyManager)(nil).BulkUpdateExpressionPKWithTx), tx, policies)
+}
+
+// DeleteByActionPKWithTx mocks base method.
 func (m *MockPolicyManager) DeleteByActionPKWithTx(tx *sqlx.Tx, actionPK, limit int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteByActionPKWithTx", tx, actionPK, limit)
@@ -218,28 +129,13 @@ func (m *MockPolicyManager) DeleteByActionPKWithTx(tx *sqlx.Tx, actionPK, limit 
 	return ret0, ret1
 }
 
-// DeleteByActionPKWithTx indicates an expected call of DeleteByActionPKWithTx
+// DeleteByActionPKWithTx indicates an expected call of DeleteByActionPKWithTx.
 func (mr *MockPolicyManagerMockRecorder) DeleteByActionPKWithTx(tx, actionPK, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByActionPKWithTx", reflect.TypeOf((*MockPolicyManager)(nil).DeleteByActionPKWithTx), tx, actionPK, limit)
 }
 
-// HasAnyByActionPK mocks base method
-func (m *MockPolicyManager) HasAnyByActionPK(actionPK int64) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasAnyByActionPK", actionPK)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HasAnyByActionPK indicates an expected call of HasAnyByActionPK
-func (mr *MockPolicyManagerMockRecorder) HasAnyByActionPK(actionPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnyByActionPK", reflect.TypeOf((*MockPolicyManager)(nil).HasAnyByActionPK), actionPK)
-}
-
-// Get mocks base method
+// Get mocks base method.
 func (m *MockPolicyManager) Get(pk int64) (dao.Policy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", pk)
@@ -248,13 +144,28 @@ func (m *MockPolicyManager) Get(pk int64) (dao.Policy, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockPolicyManagerMockRecorder) Get(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPolicyManager)(nil).Get), pk)
 }
 
-// GetCountByActionBeforeExpiredAt mocks base method
+// GetByActionTemplate mocks base method.
+func (m *MockPolicyManager) GetByActionTemplate(subjectPK, actionPK, templateID int64) (dao.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByActionTemplate", subjectPK, actionPK, templateID)
+	ret0, _ := ret[0].(dao.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByActionTemplate indicates an expected call of GetByActionTemplate.
+func (mr *MockPolicyManagerMockRecorder) GetByActionTemplate(subjectPK, actionPK, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).GetByActionTemplate), subjectPK, actionPK, templateID)
+}
+
+// GetCountByActionBeforeExpiredAt mocks base method.
 func (m *MockPolicyManager) GetCountByActionBeforeExpiredAt(actionPK, expiredAt int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCountByActionBeforeExpiredAt", actionPK, expiredAt)
@@ -263,28 +174,43 @@ func (m *MockPolicyManager) GetCountByActionBeforeExpiredAt(actionPK, expiredAt 
 	return ret0, ret1
 }
 
-// GetCountByActionBeforeExpiredAt indicates an expected call of GetCountByActionBeforeExpiredAt
+// GetCountByActionBeforeExpiredAt indicates an expected call of GetCountByActionBeforeExpiredAt.
 func (mr *MockPolicyManagerMockRecorder) GetCountByActionBeforeExpiredAt(actionPK, expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCountByActionBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).GetCountByActionBeforeExpiredAt), actionPK, expiredAt)
 }
 
-// ListPagingByActionPKBeforeExpiredAt mocks base method
-func (m *MockPolicyManager) ListPagingByActionPKBeforeExpiredAt(actionPK, expiredAt, offset, limit int64) ([]dao.Policy, error) {
+// HasAnyByActionPK mocks base method.
+func (m *MockPolicyManager) HasAnyByActionPK(actionPK int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingByActionPKBeforeExpiredAt", actionPK, expiredAt, offset, limit)
-	ret0, _ := ret[0].([]dao.Policy)
+	ret := m.ctrl.Call(m, "HasAnyByActionPK", actionPK)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListPagingByActionPKBeforeExpiredAt indicates an expected call of ListPagingByActionPKBeforeExpiredAt
-func (mr *MockPolicyManagerMockRecorder) ListPagingByActionPKBeforeExpiredAt(actionPK, expiredAt, offset, limit interface{}) *gomock.Call {
+// HasAnyByActionPK indicates an expected call of HasAnyByActionPK.
+func (mr *MockPolicyManagerMockRecorder) HasAnyByActionPK(actionPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingByActionPKBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListPagingByActionPKBeforeExpiredAt), actionPK, expiredAt, offset, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnyByActionPK", reflect.TypeOf((*MockPolicyManager)(nil).HasAnyByActionPK), actionPK)
 }
 
-// ListByPKs mocks base method
+// ListAuthBySubjectAction mocks base method.
+func (m *MockPolicyManager) ListAuthBySubjectAction(subjectPKs []int64, actionPK, expiredAt int64) ([]dao.AuthPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAuthBySubjectAction", subjectPKs, actionPK, expiredAt)
+	ret0, _ := ret[0].([]dao.AuthPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAuthBySubjectAction indicates an expected call of ListAuthBySubjectAction.
+func (mr *MockPolicyManagerMockRecorder) ListAuthBySubjectAction(subjectPKs, actionPK, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthBySubjectAction", reflect.TypeOf((*MockPolicyManager)(nil).ListAuthBySubjectAction), subjectPKs, actionPK, expiredAt)
+}
+
+// ListByPKs mocks base method.
 func (m *MockPolicyManager) ListByPKs(pks []int64) ([]dao.Policy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByPKs", pks)
@@ -293,8 +219,83 @@ func (m *MockPolicyManager) ListByPKs(pks []int64) ([]dao.Policy, error) {
 	return ret0, ret1
 }
 
-// ListByPKs indicates an expected call of ListByPKs
+// ListByPKs indicates an expected call of ListByPKs.
 func (mr *MockPolicyManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockPolicyManager)(nil).ListByPKs), pks)
+}
+
+// ListBySubjectActionTemplate mocks base method.
+func (m *MockPolicyManager) ListBySubjectActionTemplate(subjectPK int64, actionPKs []int64, templateID int64) ([]dao.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySubjectActionTemplate", subjectPK, actionPKs, templateID)
+	ret0, _ := ret[0].([]dao.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySubjectActionTemplate indicates an expected call of ListBySubjectActionTemplate.
+func (mr *MockPolicyManagerMockRecorder) ListBySubjectActionTemplate(subjectPK, actionPKs, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectActionTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectActionTemplate), subjectPK, actionPKs, templateID)
+}
+
+// ListBySubjectPKAndPKs mocks base method.
+func (m *MockPolicyManager) ListBySubjectPKAndPKs(subjectPK int64, pks []int64) ([]dao.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySubjectPKAndPKs", subjectPK, pks)
+	ret0, _ := ret[0].([]dao.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySubjectPKAndPKs indicates an expected call of ListBySubjectPKAndPKs.
+func (mr *MockPolicyManagerMockRecorder) ListBySubjectPKAndPKs(subjectPK, pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectPKAndPKs", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectPKAndPKs), subjectPK, pks)
+}
+
+// ListBySubjectTemplateBeforeExpiredAt mocks base method.
+func (m *MockPolicyManager) ListBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt int64) ([]dao.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySubjectTemplateBeforeExpiredAt", subjectPK, templateID, expiredAt)
+	ret0, _ := ret[0].([]dao.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySubjectTemplateBeforeExpiredAt indicates an expected call of ListBySubjectTemplateBeforeExpiredAt.
+func (mr *MockPolicyManagerMockRecorder) ListBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListBySubjectTemplateBeforeExpiredAt), subjectPK, templateID, expiredAt)
+}
+
+// ListExpressionBySubjectsTemplate mocks base method.
+func (m *MockPolicyManager) ListExpressionBySubjectsTemplate(subjectPKs []int64, templateID int64) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExpressionBySubjectsTemplate", subjectPKs, templateID)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExpressionBySubjectsTemplate indicates an expected call of ListExpressionBySubjectsTemplate.
+func (mr *MockPolicyManagerMockRecorder) ListExpressionBySubjectsTemplate(subjectPKs, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpressionBySubjectsTemplate", reflect.TypeOf((*MockPolicyManager)(nil).ListExpressionBySubjectsTemplate), subjectPKs, templateID)
+}
+
+// ListPagingByActionPKBeforeExpiredAt mocks base method.
+func (m *MockPolicyManager) ListPagingByActionPKBeforeExpiredAt(actionPK, expiredAt, offset, limit int64) ([]dao.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPagingByActionPKBeforeExpiredAt", actionPK, expiredAt, offset, limit)
+	ret0, _ := ret[0].([]dao.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPagingByActionPKBeforeExpiredAt indicates an expected call of ListPagingByActionPKBeforeExpiredAt.
+func (mr *MockPolicyManagerMockRecorder) ListPagingByActionPKBeforeExpiredAt(actionPK, expiredAt, offset, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingByActionPKBeforeExpiredAt", reflect.TypeOf((*MockPolicyManager)(nil).ListPagingByActionPKBeforeExpiredAt), actionPK, expiredAt, offset, limit)
 }

--- a/pkg/database/dao/mock/resource_type.go
+++ b/pkg/database/dao/mock/resource_type.go
@@ -5,36 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockResourceTypeManager is a mock of ResourceTypeManager interface
+// MockResourceTypeManager is a mock of ResourceTypeManager interface.
 type MockResourceTypeManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceTypeManagerMockRecorder
 }
 
-// MockResourceTypeManagerMockRecorder is the mock recorder for MockResourceTypeManager
+// MockResourceTypeManagerMockRecorder is the mock recorder for MockResourceTypeManager.
 type MockResourceTypeManagerMockRecorder struct {
 	mock *MockResourceTypeManager
 }
 
-// NewMockResourceTypeManager creates a new mock instance
+// NewMockResourceTypeManager creates a new mock instance.
 func NewMockResourceTypeManager(ctrl *gomock.Controller) *MockResourceTypeManager {
 	mock := &MockResourceTypeManager{ctrl: ctrl}
 	mock.recorder = &MockResourceTypeManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceTypeManager) EXPECT() *MockResourceTypeManagerMockRecorder {
 	return m.recorder
 }
 
-// BulkCreateWithTx mocks base method
+// BulkCreateWithTx mocks base method.
 func (m *MockResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, resourceTypes []dao.ResourceType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, resourceTypes)
@@ -42,13 +43,13 @@ func (m *MockResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, resourceTypes []
 	return ret0
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
 func (mr *MockResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, resourceTypes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockResourceTypeManager)(nil).BulkCreateWithTx), tx, resourceTypes)
 }
 
-// BulkDeleteWithTx mocks base method
+// BulkDeleteWithTx mocks base method.
 func (m *MockResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
@@ -56,7 +57,7 @@ func (m *MockResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, i
 	return ret0
 }
 
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
 func (mr *MockResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockResourceTypeManager)(nil).BulkDeleteWithTx), tx, system, ids)

--- a/pkg/database/dao/mock/subject.go
+++ b/pkg/database/dao/mock/subject.go
@@ -5,36 +5,79 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSubjectManager is a mock of SubjectManager interface
+// MockSubjectManager is a mock of SubjectManager interface.
 type MockSubjectManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubjectManagerMockRecorder
 }
 
-// MockSubjectManagerMockRecorder is the mock recorder for MockSubjectManager
+// MockSubjectManagerMockRecorder is the mock recorder for MockSubjectManager.
 type MockSubjectManagerMockRecorder struct {
 	mock *MockSubjectManager
 }
 
-// NewMockSubjectManager creates a new mock instance
+// NewMockSubjectManager creates a new mock instance.
 func NewMockSubjectManager(ctrl *gomock.Controller) *MockSubjectManager {
 	mock := &MockSubjectManager{ctrl: ctrl}
 	mock.recorder = &MockSubjectManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubjectManager) EXPECT() *MockSubjectManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// BulkCreate mocks base method.
+func (m *MockSubjectManager) BulkCreate(subjects []dao.Subject) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreate", subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockSubjectManagerMockRecorder) BulkCreate(subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectManager)(nil).BulkCreate), subjects)
+}
+
+// BulkDeleteByPKsWithTx mocks base method.
+func (m *MockSubjectManager) BulkDeleteByPKsWithTx(tx *sqlx.Tx, pks []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteByPKsWithTx", tx, pks)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteByPKsWithTx indicates an expected call of BulkDeleteByPKsWithTx.
+func (mr *MockSubjectManagerMockRecorder) BulkDeleteByPKsWithTx(tx, pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByPKsWithTx", reflect.TypeOf((*MockSubjectManager)(nil).BulkDeleteByPKsWithTx), tx, pks)
+}
+
+// BulkUpdate mocks base method.
+func (m *MockSubjectManager) BulkUpdate(subjects []dao.Subject) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdate", subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkUpdate indicates an expected call of BulkUpdate.
+func (mr *MockSubjectManagerMockRecorder) BulkUpdate(subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdate", reflect.TypeOf((*MockSubjectManager)(nil).BulkUpdate), subjects)
+}
+
+// Get mocks base method.
 func (m *MockSubjectManager) Get(pk int64) (dao.Subject, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", pk)
@@ -43,73 +86,13 @@ func (m *MockSubjectManager) Get(pk int64) (dao.Subject, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSubjectManagerMockRecorder) Get(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSubjectManager)(nil).Get), pk)
 }
 
-// GetPK mocks base method
-func (m *MockSubjectManager) GetPK(_type, id string) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPK", _type, id)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPK indicates an expected call of GetPK
-func (mr *MockSubjectManagerMockRecorder) GetPK(_type, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockSubjectManager)(nil).GetPK), _type, id)
-}
-
-// ListByIDs mocks base method
-func (m *MockSubjectManager) ListByIDs(_type string, ids []string) ([]dao.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByIDs", _type, ids)
-	ret0, _ := ret[0].([]dao.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByIDs indicates an expected call of ListByIDs
-func (mr *MockSubjectManagerMockRecorder) ListByIDs(_type, ids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockSubjectManager)(nil).ListByIDs), _type, ids)
-}
-
-// ListPaging mocks base method
-func (m *MockSubjectManager) ListPaging(_type string, limit, offset int64) ([]dao.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPaging", _type, limit, offset)
-	ret0, _ := ret[0].([]dao.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPaging indicates an expected call of ListPaging
-func (mr *MockSubjectManagerMockRecorder) ListPaging(_type, limit, offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaging", reflect.TypeOf((*MockSubjectManager)(nil).ListPaging), _type, limit, offset)
-}
-
-// ListByPKs mocks base method
-func (m *MockSubjectManager) ListByPKs(pks []int64) ([]dao.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByPKs", pks)
-	ret0, _ := ret[0].([]dao.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByPKs indicates an expected call of ListByPKs
-func (mr *MockSubjectManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockSubjectManager)(nil).ListByPKs), pks)
-}
-
-// GetCount mocks base method
+// GetCount mocks base method.
 func (m *MockSubjectManager) GetCount(_type string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCount", _type)
@@ -118,50 +101,68 @@ func (m *MockSubjectManager) GetCount(_type string) (int64, error) {
 	return ret0, ret1
 }
 
-// GetCount indicates an expected call of GetCount
+// GetCount indicates an expected call of GetCount.
 func (mr *MockSubjectManagerMockRecorder) GetCount(_type interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCount", reflect.TypeOf((*MockSubjectManager)(nil).GetCount), _type)
 }
 
-// BulkCreate mocks base method
-func (m *MockSubjectManager) BulkCreate(subjects []dao.Subject) error {
+// GetPK mocks base method.
+func (m *MockSubjectManager) GetPK(_type, id string) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", subjects)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetPK", _type, id)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockSubjectManagerMockRecorder) BulkCreate(subjects interface{}) *gomock.Call {
+// GetPK indicates an expected call of GetPK.
+func (mr *MockSubjectManagerMockRecorder) GetPK(_type, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectManager)(nil).BulkCreate), subjects)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockSubjectManager)(nil).GetPK), _type, id)
 }
 
-// BulkDeleteByPKsWithTx mocks base method
-func (m *MockSubjectManager) BulkDeleteByPKsWithTx(tx *sqlx.Tx, pks []int64) error {
+// ListByIDs mocks base method.
+func (m *MockSubjectManager) ListByIDs(_type string, ids []string) ([]dao.Subject, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteByPKsWithTx", tx, pks)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ListByIDs", _type, ids)
+	ret0, _ := ret[0].([]dao.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// BulkDeleteByPKsWithTx indicates an expected call of BulkDeleteByPKsWithTx
-func (mr *MockSubjectManagerMockRecorder) BulkDeleteByPKsWithTx(tx, pks interface{}) *gomock.Call {
+// ListByIDs indicates an expected call of ListByIDs.
+func (mr *MockSubjectManagerMockRecorder) ListByIDs(_type, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByPKsWithTx", reflect.TypeOf((*MockSubjectManager)(nil).BulkDeleteByPKsWithTx), tx, pks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockSubjectManager)(nil).ListByIDs), _type, ids)
 }
 
-// BulkUpdate mocks base method
-func (m *MockSubjectManager) BulkUpdate(subjects []dao.Subject) error {
+// ListByPKs mocks base method.
+func (m *MockSubjectManager) ListByPKs(pks []int64) ([]dao.Subject, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdate", subjects)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ListByPKs", pks)
+	ret0, _ := ret[0].([]dao.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// BulkUpdate indicates an expected call of BulkUpdate
-func (mr *MockSubjectManagerMockRecorder) BulkUpdate(subjects interface{}) *gomock.Call {
+// ListByPKs indicates an expected call of ListByPKs.
+func (mr *MockSubjectManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdate", reflect.TypeOf((*MockSubjectManager)(nil).BulkUpdate), subjects)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockSubjectManager)(nil).ListByPKs), pks)
+}
+
+// ListPaging mocks base method.
+func (m *MockSubjectManager) ListPaging(_type string, limit, offset int64) ([]dao.Subject, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPaging", _type, limit, offset)
+	ret0, _ := ret[0].([]dao.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPaging indicates an expected call of ListPaging.
+func (mr *MockSubjectManagerMockRecorder) ListPaging(_type, limit, offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaging", reflect.TypeOf((*MockSubjectManager)(nil).ListPaging), _type, limit, offset)
 }

--- a/pkg/database/dao/mock/subject_department.go
+++ b/pkg/database/dao/mock/subject_department.go
@@ -5,36 +5,93 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSubjectDepartmentManager is a mock of SubjectDepartmentManager interface
+// MockSubjectDepartmentManager is a mock of SubjectDepartmentManager interface.
 type MockSubjectDepartmentManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubjectDepartmentManagerMockRecorder
 }
 
-// MockSubjectDepartmentManagerMockRecorder is the mock recorder for MockSubjectDepartmentManager
+// MockSubjectDepartmentManagerMockRecorder is the mock recorder for MockSubjectDepartmentManager.
 type MockSubjectDepartmentManagerMockRecorder struct {
 	mock *MockSubjectDepartmentManager
 }
 
-// NewMockSubjectDepartmentManager creates a new mock instance
+// NewMockSubjectDepartmentManager creates a new mock instance.
 func NewMockSubjectDepartmentManager(ctrl *gomock.Controller) *MockSubjectDepartmentManager {
 	mock := &MockSubjectDepartmentManager{ctrl: ctrl}
 	mock.recorder = &MockSubjectDepartmentManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubjectDepartmentManager) EXPECT() *MockSubjectDepartmentManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// BulkCreate mocks base method.
+func (m *MockSubjectDepartmentManager) BulkCreate(subjectDepartments []dao.SubjectDepartment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreate", subjectDepartments)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockSubjectDepartmentManagerMockRecorder) BulkCreate(subjectDepartments interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkCreate), subjectDepartments)
+}
+
+// BulkDelete mocks base method.
+func (m *MockSubjectDepartmentManager) BulkDelete(subjectPKs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDelete", subjectPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDelete indicates an expected call of BulkDelete.
+func (mr *MockSubjectDepartmentManagerMockRecorder) BulkDelete(subjectPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkDelete), subjectPKs)
+}
+
+// BulkDeleteWithTx mocks base method.
+func (m *MockSubjectDepartmentManager) BulkDeleteWithTx(tx *sqlx.Tx, subjectPKs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, subjectPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockSubjectDepartmentManagerMockRecorder) BulkDeleteWithTx(tx, subjectPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkDeleteWithTx), tx, subjectPKs)
+}
+
+// BulkUpdate mocks base method.
+func (m *MockSubjectDepartmentManager) BulkUpdate(subjectDepartments []dao.SubjectDepartment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdate", subjectDepartments)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkUpdate indicates an expected call of BulkUpdate.
+func (mr *MockSubjectDepartmentManagerMockRecorder) BulkUpdate(subjectDepartments interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdate", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkUpdate), subjectDepartments)
+}
+
+// Get mocks base method.
 func (m *MockSubjectDepartmentManager) Get(subjectPK int64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", subjectPK)
@@ -43,13 +100,13 @@ func (m *MockSubjectDepartmentManager) Get(subjectPK int64) (string, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSubjectDepartmentManagerMockRecorder) Get(subjectPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).Get), subjectPK)
 }
 
-// GetCount mocks base method
+// GetCount mocks base method.
 func (m *MockSubjectDepartmentManager) GetCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCount")
@@ -58,13 +115,13 @@ func (m *MockSubjectDepartmentManager) GetCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetCount indicates an expected call of GetCount
+// GetCount indicates an expected call of GetCount.
 func (mr *MockSubjectDepartmentManagerMockRecorder) GetCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCount", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).GetCount))
 }
 
-// ListPaging mocks base method
+// ListPaging mocks base method.
 func (m *MockSubjectDepartmentManager) ListPaging(limit, offset int64) ([]dao.SubjectDepartment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPaging", limit, offset)
@@ -73,64 +130,8 @@ func (m *MockSubjectDepartmentManager) ListPaging(limit, offset int64) ([]dao.Su
 	return ret0, ret1
 }
 
-// ListPaging indicates an expected call of ListPaging
+// ListPaging indicates an expected call of ListPaging.
 func (mr *MockSubjectDepartmentManagerMockRecorder) ListPaging(limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaging", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).ListPaging), limit, offset)
-}
-
-// BulkCreate mocks base method
-func (m *MockSubjectDepartmentManager) BulkCreate(subjectDepartments []dao.SubjectDepartment) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", subjectDepartments)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockSubjectDepartmentManagerMockRecorder) BulkCreate(subjectDepartments interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkCreate), subjectDepartments)
-}
-
-// BulkUpdate mocks base method
-func (m *MockSubjectDepartmentManager) BulkUpdate(subjectDepartments []dao.SubjectDepartment) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdate", subjectDepartments)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkUpdate indicates an expected call of BulkUpdate
-func (mr *MockSubjectDepartmentManagerMockRecorder) BulkUpdate(subjectDepartments interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdate", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkUpdate), subjectDepartments)
-}
-
-// BulkDelete mocks base method
-func (m *MockSubjectDepartmentManager) BulkDelete(subjectPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDelete", subjectPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDelete indicates an expected call of BulkDelete
-func (mr *MockSubjectDepartmentManagerMockRecorder) BulkDelete(subjectPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkDelete), subjectPKs)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockSubjectDepartmentManager) BulkDeleteWithTx(tx *sqlx.Tx, subjectPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, subjectPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockSubjectDepartmentManagerMockRecorder) BulkDeleteWithTx(tx, subjectPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSubjectDepartmentManager)(nil).BulkDeleteWithTx), tx, subjectPKs)
 }

--- a/pkg/database/dao/mock/subject_relation.go
+++ b/pkg/database/dao/mock/subject_relation.go
@@ -5,81 +5,124 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSubjectRelationManager is a mock of SubjectRelationManager interface
+// MockSubjectRelationManager is a mock of SubjectRelationManager interface.
 type MockSubjectRelationManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubjectRelationManagerMockRecorder
 }
 
-// MockSubjectRelationManagerMockRecorder is the mock recorder for MockSubjectRelationManager
+// MockSubjectRelationManagerMockRecorder is the mock recorder for MockSubjectRelationManager.
 type MockSubjectRelationManagerMockRecorder struct {
 	mock *MockSubjectRelationManager
 }
 
-// NewMockSubjectRelationManager creates a new mock instance
+// NewMockSubjectRelationManager creates a new mock instance.
 func NewMockSubjectRelationManager(ctrl *gomock.Controller) *MockSubjectRelationManager {
 	mock := &MockSubjectRelationManager{ctrl: ctrl}
 	mock.recorder = &MockSubjectRelationManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubjectRelationManager) EXPECT() *MockSubjectRelationManagerMockRecorder {
 	return m.recorder
 }
 
-// ListRelation mocks base method
-func (m *MockSubjectRelationManager) ListRelation(_type, id string) ([]dao.SubjectRelation, error) {
+// BulkCreate mocks base method.
+func (m *MockSubjectRelationManager) BulkCreate(relations []dao.SubjectRelation) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRelation", _type, id)
-	ret0, _ := ret[0].([]dao.SubjectRelation)
+	ret := m.ctrl.Call(m, "BulkCreate", relations)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockSubjectRelationManagerMockRecorder) BulkCreate(relations interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkCreate), relations)
+}
+
+// BulkDeleteByMembersWithTx mocks base method.
+func (m *MockSubjectRelationManager) BulkDeleteByMembersWithTx(tx *sqlx.Tx, parentPK int64, subjectPKs []int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteByMembersWithTx", tx, parentPK, subjectPKs)
+	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListRelation indicates an expected call of ListRelation
-func (mr *MockSubjectRelationManagerMockRecorder) ListRelation(_type, id interface{}) *gomock.Call {
+// BulkDeleteByMembersWithTx indicates an expected call of BulkDeleteByMembersWithTx.
+func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteByMembersWithTx(tx, parentPK, subjectPKs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelation", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelation), _type, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByMembersWithTx", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteByMembersWithTx), tx, parentPK, subjectPKs)
 }
 
-// ListRelationBySubjectPK mocks base method
-func (m *MockSubjectRelationManager) ListRelationBySubjectPK(subjectPK int64) ([]dao.SubjectRelation, error) {
+// BulkDeleteByParentPKs mocks base method.
+func (m *MockSubjectRelationManager) BulkDeleteByParentPKs(tx *sqlx.Tx, parentPKs []int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRelationBySubjectPK", subjectPK)
-	ret0, _ := ret[0].([]dao.SubjectRelation)
+	ret := m.ctrl.Call(m, "BulkDeleteByParentPKs", tx, parentPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteByParentPKs indicates an expected call of BulkDeleteByParentPKs.
+func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteByParentPKs(tx, parentPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByParentPKs", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteByParentPKs), tx, parentPKs)
+}
+
+// BulkDeleteBySubjectPKs mocks base method.
+func (m *MockSubjectRelationManager) BulkDeleteBySubjectPKs(tx *sqlx.Tx, subjectPKs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteBySubjectPKs", tx, subjectPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteBySubjectPKs indicates an expected call of BulkDeleteBySubjectPKs.
+func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteBySubjectPKs(tx, subjectPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectPKs", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteBySubjectPKs), tx, subjectPKs)
+}
+
+// GetMemberCount mocks base method.
+func (m *MockSubjectRelationManager) GetMemberCount(parentPK int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemberCount", parentPK)
+	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListRelationBySubjectPK indicates an expected call of ListRelationBySubjectPK
-func (mr *MockSubjectRelationManagerMockRecorder) ListRelationBySubjectPK(subjectPK interface{}) *gomock.Call {
+// GetMemberCount indicates an expected call of GetMemberCount.
+func (mr *MockSubjectRelationManagerMockRecorder) GetMemberCount(parentPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelationBySubjectPK), subjectPK)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockSubjectRelationManager)(nil).GetMemberCount), parentPK)
 }
 
-// ListEffectThinRelationBySubjectPK mocks base method
-func (m *MockSubjectRelationManager) ListEffectThinRelationBySubjectPK(subjectPK int64) ([]dao.ThinSubjectRelation, error) {
+// GetMemberCountBeforeExpiredAt mocks base method.
+func (m *MockSubjectRelationManager) GetMemberCountBeforeExpiredAt(parentPK, expiredAt int64) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEffectThinRelationBySubjectPK", subjectPK)
-	ret0, _ := ret[0].([]dao.ThinSubjectRelation)
+	ret := m.ctrl.Call(m, "GetMemberCountBeforeExpiredAt", parentPK, expiredAt)
+	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListEffectThinRelationBySubjectPK indicates an expected call of ListEffectThinRelationBySubjectPK
-func (mr *MockSubjectRelationManagerMockRecorder) ListEffectThinRelationBySubjectPK(subjectPK interface{}) *gomock.Call {
+// GetMemberCountBeforeExpiredAt indicates an expected call of GetMemberCountBeforeExpiredAt.
+func (mr *MockSubjectRelationManagerMockRecorder) GetMemberCountBeforeExpiredAt(parentPK, expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListEffectThinRelationBySubjectPK), subjectPK)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).GetMemberCountBeforeExpiredAt), parentPK, expiredAt)
 }
 
-// ListEffectRelationBySubjectPKs mocks base method
+// ListEffectRelationBySubjectPKs mocks base method.
 func (m *MockSubjectRelationManager) ListEffectRelationBySubjectPKs(subjectPKs []int64) ([]dao.EffectSubjectRelation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEffectRelationBySubjectPKs", subjectPKs)
@@ -88,118 +131,118 @@ func (m *MockSubjectRelationManager) ListEffectRelationBySubjectPKs(subjectPKs [
 	return ret0, ret1
 }
 
-// ListEffectRelationBySubjectPKs indicates an expected call of ListEffectRelationBySubjectPKs
+// ListEffectRelationBySubjectPKs indicates an expected call of ListEffectRelationBySubjectPKs.
 func (mr *MockSubjectRelationManagerMockRecorder) ListEffectRelationBySubjectPKs(subjectPKs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectRelationBySubjectPKs", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListEffectRelationBySubjectPKs), subjectPKs)
 }
 
-// ListRelationBeforeExpiredAt mocks base method
-func (m *MockSubjectRelationManager) ListRelationBeforeExpiredAt(_type, id string, expiredAt int64) ([]dao.SubjectRelation, error) {
+// ListEffectThinRelationBySubjectPK mocks base method.
+func (m *MockSubjectRelationManager) ListEffectThinRelationBySubjectPK(subjectPK int64) ([]dao.ThinSubjectRelation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRelationBeforeExpiredAt", _type, id, expiredAt)
+	ret := m.ctrl.Call(m, "ListEffectThinRelationBySubjectPK", subjectPK)
+	ret0, _ := ret[0].([]dao.ThinSubjectRelation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEffectThinRelationBySubjectPK indicates an expected call of ListEffectThinRelationBySubjectPK.
+func (mr *MockSubjectRelationManagerMockRecorder) ListEffectThinRelationBySubjectPK(subjectPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinRelationBySubjectPK", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListEffectThinRelationBySubjectPK), subjectPK)
+}
+
+// ListMember mocks base method.
+func (m *MockSubjectRelationManager) ListMember(parentPK int64) ([]dao.SubjectRelation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMember", parentPK)
 	ret0, _ := ret[0].([]dao.SubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListRelationBeforeExpiredAt indicates an expected call of ListRelationBeforeExpiredAt
-func (mr *MockSubjectRelationManagerMockRecorder) ListRelationBeforeExpiredAt(_type, id, expiredAt interface{}) *gomock.Call {
+// ListMember indicates an expected call of ListMember.
+func (mr *MockSubjectRelationManagerMockRecorder) ListMember(parentPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelationBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelationBeforeExpiredAt), _type, id, expiredAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMember", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListMember), parentPK)
 }
 
-// ListPagingMember mocks base method
-func (m *MockSubjectRelationManager) ListPagingMember(_type, id string, limit, offset int64) ([]dao.SubjectRelation, error) {
+// ListPagingMember mocks base method.
+func (m *MockSubjectRelationManager) ListPagingMember(parentPK, limit, offset int64) ([]dao.SubjectRelation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingMember", _type, id, limit, offset)
+	ret := m.ctrl.Call(m, "ListPagingMember", parentPK, limit, offset)
 	ret0, _ := ret[0].([]dao.SubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListPagingMember indicates an expected call of ListPagingMember
-func (mr *MockSubjectRelationManagerMockRecorder) ListPagingMember(_type, id, limit, offset interface{}) *gomock.Call {
+// ListPagingMember indicates an expected call of ListPagingMember.
+func (mr *MockSubjectRelationManagerMockRecorder) ListPagingMember(parentPK, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMember", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListPagingMember), _type, id, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMember", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListPagingMember), parentPK, limit, offset)
 }
 
-// ListPagingMemberBeforeExpiredAt mocks base method
-func (m *MockSubjectRelationManager) ListPagingMemberBeforeExpiredAt(_type, id string, expiredAt, limit, offset int64) ([]dao.SubjectRelation, error) {
+// ListPagingMemberBeforeExpiredAt mocks base method.
+func (m *MockSubjectRelationManager) ListPagingMemberBeforeExpiredAt(parentPK, expiredAt, limit, offset int64) ([]dao.SubjectRelation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingMemberBeforeExpiredAt", _type, id, expiredAt, limit, offset)
+	ret := m.ctrl.Call(m, "ListPagingMemberBeforeExpiredAt", parentPK, expiredAt, limit, offset)
 	ret0, _ := ret[0].([]dao.SubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListPagingMemberBeforeExpiredAt indicates an expected call of ListPagingMemberBeforeExpiredAt
-func (mr *MockSubjectRelationManagerMockRecorder) ListPagingMemberBeforeExpiredAt(_type, id, expiredAt, limit, offset interface{}) *gomock.Call {
+// ListPagingMemberBeforeExpiredAt indicates an expected call of ListPagingMemberBeforeExpiredAt.
+func (mr *MockSubjectRelationManagerMockRecorder) ListPagingMemberBeforeExpiredAt(parentPK, expiredAt, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMemberBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListPagingMemberBeforeExpiredAt), _type, id, expiredAt, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMemberBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListPagingMemberBeforeExpiredAt), parentPK, expiredAt, limit, offset)
 }
 
-// ListMember mocks base method
-func (m *MockSubjectRelationManager) ListMember(_type, id string) ([]dao.SubjectRelation, error) {
+// ListParentPKsBeforeExpiredAt mocks base method.
+func (m *MockSubjectRelationManager) ListParentPKsBeforeExpiredAt(parentPKs []int64, expiredAt int64) ([]int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMember", _type, id)
+	ret := m.ctrl.Call(m, "ListParentPKsBeforeExpiredAt", parentPKs, expiredAt)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListParentPKsBeforeExpiredAt indicates an expected call of ListParentPKsBeforeExpiredAt.
+func (mr *MockSubjectRelationManagerMockRecorder) ListParentPKsBeforeExpiredAt(parentPKs, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParentPKsBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListParentPKsBeforeExpiredAt), parentPKs, expiredAt)
+}
+
+// ListRelation mocks base method.
+func (m *MockSubjectRelationManager) ListRelation(subjectPK int64) ([]dao.SubjectRelation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRelation", subjectPK)
 	ret0, _ := ret[0].([]dao.SubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListMember indicates an expected call of ListMember
-func (mr *MockSubjectRelationManagerMockRecorder) ListMember(_type, id interface{}) *gomock.Call {
+// ListRelation indicates an expected call of ListRelation.
+func (mr *MockSubjectRelationManagerMockRecorder) ListRelation(subjectPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMember", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListMember), _type, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelation", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelation), subjectPK)
 }
 
-// GetMemberCount mocks base method
-func (m *MockSubjectRelationManager) GetMemberCount(_type, id string) (int64, error) {
+// ListRelationBeforeExpiredAt mocks base method.
+func (m *MockSubjectRelationManager) ListRelationBeforeExpiredAt(subjectPK, expiredAt int64) ([]dao.SubjectRelation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCount", _type, id)
-	ret0, _ := ret[0].(int64)
+	ret := m.ctrl.Call(m, "ListRelationBeforeExpiredAt", subjectPK, expiredAt)
+	ret0, _ := ret[0].([]dao.SubjectRelation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMemberCount indicates an expected call of GetMemberCount
-func (mr *MockSubjectRelationManagerMockRecorder) GetMemberCount(_type, id interface{}) *gomock.Call {
+// ListRelationBeforeExpiredAt indicates an expected call of ListRelationBeforeExpiredAt.
+func (mr *MockSubjectRelationManagerMockRecorder) ListRelationBeforeExpiredAt(subjectPK, expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockSubjectRelationManager)(nil).GetMemberCount), _type, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRelationBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListRelationBeforeExpiredAt), subjectPK, expiredAt)
 }
 
-// GetMemberCountBeforeExpiredAt mocks base method
-func (m *MockSubjectRelationManager) GetMemberCountBeforeExpiredAt(_type, id string, expiredAt int64) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCountBeforeExpiredAt", _type, id, expiredAt)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemberCountBeforeExpiredAt indicates an expected call of GetMemberCountBeforeExpiredAt
-func (mr *MockSubjectRelationManagerMockRecorder) GetMemberCountBeforeExpiredAt(_type, id, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).GetMemberCountBeforeExpiredAt), _type, id, expiredAt)
-}
-
-// ListParentIDsBeforeExpiredAt mocks base method
-func (m *MockSubjectRelationManager) ListParentIDsBeforeExpiredAt(_type string, ids []string, expiredAt int64) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListParentIDsBeforeExpiredAt", _type, ids, expiredAt)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListParentIDsBeforeExpiredAt indicates an expected call of ListParentIDsBeforeExpiredAt
-func (mr *MockSubjectRelationManagerMockRecorder) ListParentIDsBeforeExpiredAt(_type, ids, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParentIDsBeforeExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).ListParentIDsBeforeExpiredAt), _type, ids, expiredAt)
-}
-
-// UpdateExpiredAt mocks base method
+// UpdateExpiredAt mocks base method.
 func (m *MockSubjectRelationManager) UpdateExpiredAt(relations []dao.SubjectRelationPKPolicyExpiredAt) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateExpiredAt", relations)
@@ -207,65 +250,8 @@ func (m *MockSubjectRelationManager) UpdateExpiredAt(relations []dao.SubjectRela
 	return ret0
 }
 
-// UpdateExpiredAt indicates an expected call of UpdateExpiredAt
+// UpdateExpiredAt indicates an expected call of UpdateExpiredAt.
 func (mr *MockSubjectRelationManagerMockRecorder) UpdateExpiredAt(relations interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExpiredAt", reflect.TypeOf((*MockSubjectRelationManager)(nil).UpdateExpiredAt), relations)
-}
-
-// BulkDeleteByMembersWithTx mocks base method
-func (m *MockSubjectRelationManager) BulkDeleteByMembersWithTx(tx *sqlx.Tx, _type, id, subjectType string, subjectIDs []string) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteByMembersWithTx", tx, _type, id, subjectType, subjectIDs)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BulkDeleteByMembersWithTx indicates an expected call of BulkDeleteByMembersWithTx
-func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteByMembersWithTx(tx, _type, id, subjectType, subjectIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByMembersWithTx", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteByMembersWithTx), tx, _type, id, subjectType, subjectIDs)
-}
-
-// BulkCreate mocks base method
-func (m *MockSubjectRelationManager) BulkCreate(relations []dao.SubjectRelation) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", relations)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockSubjectRelationManagerMockRecorder) BulkCreate(relations interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkCreate), relations)
-}
-
-// BulkDeleteBySubjectPKs mocks base method
-func (m *MockSubjectRelationManager) BulkDeleteBySubjectPKs(tx *sqlx.Tx, subjectPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteBySubjectPKs", tx, subjectPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteBySubjectPKs indicates an expected call of BulkDeleteBySubjectPKs
-func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteBySubjectPKs(tx, subjectPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBySubjectPKs", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteBySubjectPKs), tx, subjectPKs)
-}
-
-// BulkDeleteByParentPKs mocks base method
-func (m *MockSubjectRelationManager) BulkDeleteByParentPKs(tx *sqlx.Tx, parentPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteByParentPKs", tx, parentPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteByParentPKs indicates an expected call of BulkDeleteByParentPKs
-func (mr *MockSubjectRelationManagerMockRecorder) BulkDeleteByParentPKs(tx, parentPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByParentPKs", reflect.TypeOf((*MockSubjectRelationManager)(nil).BulkDeleteByParentPKs), tx, parentPKs)
 }

--- a/pkg/database/dao/mock/subject_role.go
+++ b/pkg/database/dao/mock/subject_role.go
@@ -5,35 +5,64 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSubjectRoleManager is a mock of SubjectRoleManager interface
+// MockSubjectRoleManager is a mock of SubjectRoleManager interface.
 type MockSubjectRoleManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubjectRoleManagerMockRecorder
 }
 
-// MockSubjectRoleManagerMockRecorder is the mock recorder for MockSubjectRoleManager
+// MockSubjectRoleManagerMockRecorder is the mock recorder for MockSubjectRoleManager.
 type MockSubjectRoleManagerMockRecorder struct {
 	mock *MockSubjectRoleManager
 }
 
-// NewMockSubjectRoleManager creates a new mock instance
+// NewMockSubjectRoleManager creates a new mock instance.
 func NewMockSubjectRoleManager(ctrl *gomock.Controller) *MockSubjectRoleManager {
 	mock := &MockSubjectRoleManager{ctrl: ctrl}
 	mock.recorder = &MockSubjectRoleManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubjectRoleManager) EXPECT() *MockSubjectRoleManagerMockRecorder {
 	return m.recorder
 }
 
-// ListSubjectPKByRole mocks base method
+// BulkCreate mocks base method.
+func (m *MockSubjectRoleManager) BulkCreate(roles []dao.SubjectRole) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreate", roles)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockSubjectRoleManagerMockRecorder) BulkCreate(roles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectRoleManager)(nil).BulkCreate), roles)
+}
+
+// BulkDelete mocks base method.
+func (m *MockSubjectRoleManager) BulkDelete(roleType, system string, subjectPKs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDelete", roleType, system, subjectPKs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDelete indicates an expected call of BulkDelete.
+func (mr *MockSubjectRoleManagerMockRecorder) BulkDelete(roleType, system, subjectPKs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockSubjectRoleManager)(nil).BulkDelete), roleType, system, subjectPKs)
+}
+
+// ListSubjectPKByRole mocks base method.
 func (m *MockSubjectRoleManager) ListSubjectPKByRole(roleType, system string) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSubjectPKByRole", roleType, system)
@@ -42,13 +71,13 @@ func (m *MockSubjectRoleManager) ListSubjectPKByRole(roleType, system string) ([
 	return ret0, ret1
 }
 
-// ListSubjectPKByRole indicates an expected call of ListSubjectPKByRole
+// ListSubjectPKByRole indicates an expected call of ListSubjectPKByRole.
 func (mr *MockSubjectRoleManagerMockRecorder) ListSubjectPKByRole(roleType, system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectPKByRole", reflect.TypeOf((*MockSubjectRoleManager)(nil).ListSubjectPKByRole), roleType, system)
 }
 
-// ListSystemIDBySubjectPK mocks base method
+// ListSystemIDBySubjectPK mocks base method.
 func (m *MockSubjectRoleManager) ListSystemIDBySubjectPK(pk int64) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSystemIDBySubjectPK", pk)
@@ -57,36 +86,8 @@ func (m *MockSubjectRoleManager) ListSystemIDBySubjectPK(pk int64) ([]string, er
 	return ret0, ret1
 }
 
-// ListSystemIDBySubjectPK indicates an expected call of ListSystemIDBySubjectPK
+// ListSystemIDBySubjectPK indicates an expected call of ListSystemIDBySubjectPK.
 func (mr *MockSubjectRoleManagerMockRecorder) ListSystemIDBySubjectPK(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSystemIDBySubjectPK", reflect.TypeOf((*MockSubjectRoleManager)(nil).ListSystemIDBySubjectPK), pk)
-}
-
-// BulkCreate mocks base method
-func (m *MockSubjectRoleManager) BulkCreate(roles []dao.SubjectRole) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", roles)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockSubjectRoleManagerMockRecorder) BulkCreate(roles interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectRoleManager)(nil).BulkCreate), roles)
-}
-
-// BulkDelete mocks base method
-func (m *MockSubjectRoleManager) BulkDelete(roleType, system string, subjectPKs []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDelete", roleType, system, subjectPKs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDelete indicates an expected call of BulkDelete
-func (mr *MockSubjectRoleManagerMockRecorder) BulkDelete(roleType, system, subjectPKs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockSubjectRoleManager)(nil).BulkDelete), roleType, system, subjectPKs)
 }

--- a/pkg/database/dao/mock/system.go
+++ b/pkg/database/dao/mock/system.go
@@ -5,36 +5,51 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSystemManager is a mock of SystemManager interface
+// MockSystemManager is a mock of SystemManager interface.
 type MockSystemManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSystemManagerMockRecorder
 }
 
-// MockSystemManagerMockRecorder is the mock recorder for MockSystemManager
+// MockSystemManagerMockRecorder is the mock recorder for MockSystemManager.
 type MockSystemManagerMockRecorder struct {
 	mock *MockSystemManager
 }
 
-// NewMockSystemManager creates a new mock instance
+// NewMockSystemManager creates a new mock instance.
 func NewMockSystemManager(ctrl *gomock.Controller) *MockSystemManager {
 	mock := &MockSystemManager{ctrl: ctrl}
 	mock.recorder = &MockSystemManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSystemManager) EXPECT() *MockSystemManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// CreateWithTx mocks base method.
+func (m *MockSystemManager) CreateWithTx(tx *sqlx.Tx, system dao.System) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWithTx", tx, system)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateWithTx indicates an expected call of CreateWithTx.
+func (mr *MockSystemManagerMockRecorder) CreateWithTx(tx, system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithTx", reflect.TypeOf((*MockSystemManager)(nil).CreateWithTx), tx, system)
+}
+
+// Get mocks base method.
 func (m *MockSystemManager) Get(id string) (dao.System, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", id)
@@ -43,22 +58,8 @@ func (m *MockSystemManager) Get(id string) (dao.System, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSystemManagerMockRecorder) Get(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSystemManager)(nil).Get), id)
-}
-
-// CreateWithTx mocks base method
-func (m *MockSystemManager) CreateWithTx(tx *sqlx.Tx, system dao.System) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWithTx", tx, system)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateWithTx indicates an expected call of CreateWithTx
-func (mr *MockSystemManagerMockRecorder) CreateWithTx(tx, system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithTx", reflect.TypeOf((*MockSystemManager)(nil).CreateWithTx), tx, system)
 }

--- a/pkg/database/dao/mock/temporary_policy.go
+++ b/pkg/database/dao/mock/temporary_policy.go
@@ -5,66 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	dao "iam/pkg/database/dao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockTemporaryPolicyManager is a mock of TemporaryPolicyManager interface
+// MockTemporaryPolicyManager is a mock of TemporaryPolicyManager interface.
 type MockTemporaryPolicyManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemporaryPolicyManagerMockRecorder
 }
 
-// MockTemporaryPolicyManagerMockRecorder is the mock recorder for MockTemporaryPolicyManager
+// MockTemporaryPolicyManagerMockRecorder is the mock recorder for MockTemporaryPolicyManager.
 type MockTemporaryPolicyManagerMockRecorder struct {
 	mock *MockTemporaryPolicyManager
 }
 
-// NewMockTemporaryPolicyManager creates a new mock instance
+// NewMockTemporaryPolicyManager creates a new mock instance.
 func NewMockTemporaryPolicyManager(ctrl *gomock.Controller) *MockTemporaryPolicyManager {
 	mock := &MockTemporaryPolicyManager{ctrl: ctrl}
 	mock.recorder = &MockTemporaryPolicyManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTemporaryPolicyManager) EXPECT() *MockTemporaryPolicyManagerMockRecorder {
 	return m.recorder
 }
 
-// ListThinBySubjectAction mocks base method
-func (m *MockTemporaryPolicyManager) ListThinBySubjectAction(subjectPK, actionPK, expiredAt int64) ([]dao.ThinTemporaryPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinBySubjectAction", subjectPK, actionPK, expiredAt)
-	ret0, _ := ret[0].([]dao.ThinTemporaryPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinBySubjectAction indicates an expected call of ListThinBySubjectAction
-func (mr *MockTemporaryPolicyManagerMockRecorder) ListThinBySubjectAction(subjectPK, actionPK, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectAction", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).ListThinBySubjectAction), subjectPK, actionPK, expiredAt)
-}
-
-// ListByPKs mocks base method
-func (m *MockTemporaryPolicyManager) ListByPKs(pks []int64) ([]dao.TemporaryPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByPKs", pks)
-	ret0, _ := ret[0].([]dao.TemporaryPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByPKs indicates an expected call of ListByPKs
-func (mr *MockTemporaryPolicyManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).ListByPKs), pks)
-}
-
-// BulkCreateWithTx mocks base method
+// BulkCreateWithTx mocks base method.
 func (m *MockTemporaryPolicyManager) BulkCreateWithTx(tx *sqlx.Tx, policies []dao.TemporaryPolicy) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, policies)
@@ -73,28 +44,13 @@ func (m *MockTemporaryPolicyManager) BulkCreateWithTx(tx *sqlx.Tx, policies []da
 	return ret0, ret1
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
 func (mr *MockTemporaryPolicyManagerMockRecorder) BulkCreateWithTx(tx, policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).BulkCreateWithTx), tx, policies)
 }
 
-// BulkDeleteByPKs mocks base method
-func (m *MockTemporaryPolicyManager) BulkDeleteByPKs(subjectPK int64, pks []int64) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteByPKs", subjectPK, pks)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BulkDeleteByPKs indicates an expected call of BulkDeleteByPKs
-func (mr *MockTemporaryPolicyManagerMockRecorder) BulkDeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByPKs", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).BulkDeleteByPKs), subjectPK, pks)
-}
-
-// BulkDeleteBeforeExpiredAtWithTx mocks base method
+// BulkDeleteBeforeExpiredAtWithTx mocks base method.
 func (m *MockTemporaryPolicyManager) BulkDeleteBeforeExpiredAtWithTx(tx *sqlx.Tx, expiredAt, limit int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteBeforeExpiredAtWithTx", tx, expiredAt, limit)
@@ -103,8 +59,53 @@ func (m *MockTemporaryPolicyManager) BulkDeleteBeforeExpiredAtWithTx(tx *sqlx.Tx
 	return ret0, ret1
 }
 
-// BulkDeleteBeforeExpiredAtWithTx indicates an expected call of BulkDeleteBeforeExpiredAtWithTx
+// BulkDeleteBeforeExpiredAtWithTx indicates an expected call of BulkDeleteBeforeExpiredAtWithTx.
 func (mr *MockTemporaryPolicyManagerMockRecorder) BulkDeleteBeforeExpiredAtWithTx(tx, expiredAt, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteBeforeExpiredAtWithTx", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).BulkDeleteBeforeExpiredAtWithTx), tx, expiredAt, limit)
+}
+
+// BulkDeleteByPKs mocks base method.
+func (m *MockTemporaryPolicyManager) BulkDeleteByPKs(subjectPK int64, pks []int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteByPKs", subjectPK, pks)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BulkDeleteByPKs indicates an expected call of BulkDeleteByPKs.
+func (mr *MockTemporaryPolicyManagerMockRecorder) BulkDeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteByPKs", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).BulkDeleteByPKs), subjectPK, pks)
+}
+
+// ListByPKs mocks base method.
+func (m *MockTemporaryPolicyManager) ListByPKs(pks []int64) ([]dao.TemporaryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByPKs", pks)
+	ret0, _ := ret[0].([]dao.TemporaryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByPKs indicates an expected call of ListByPKs.
+func (mr *MockTemporaryPolicyManagerMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).ListByPKs), pks)
+}
+
+// ListThinBySubjectAction mocks base method.
+func (m *MockTemporaryPolicyManager) ListThinBySubjectAction(subjectPK, actionPK, expiredAt int64) ([]dao.ThinTemporaryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinBySubjectAction", subjectPK, actionPK, expiredAt)
+	ret0, _ := ret[0].([]dao.ThinTemporaryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinBySubjectAction indicates an expected call of ListThinBySubjectAction.
+func (mr *MockTemporaryPolicyManagerMockRecorder) ListThinBySubjectAction(subjectPK, actionPK, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectAction", reflect.TypeOf((*MockTemporaryPolicyManager)(nil).ListThinBySubjectAction), subjectPK, actionPK, expiredAt)
 }

--- a/pkg/database/dao/subject.go
+++ b/pkg/database/dao/subject.go
@@ -104,9 +104,9 @@ func (m *subjectManager) ListPaging(_type string, limit, offset int64) (subjects
 
 // GetCount ...
 func (m *subjectManager) GetCount(_type string) (int64, error) {
-	var cnt int64
-	err := m.getCount(&cnt, _type)
-	return cnt, err
+	var count int64
+	err := m.getCount(&count, _type)
+	return count, err
 }
 
 // BulkCreate ...
@@ -194,12 +194,12 @@ func (m *subjectManager) selectPagingSubjects(subjects *[]Subject, _type string,
 	return database.SqlxSelect(m.DB, subjects, query, _type, limit, offset)
 }
 
-func (m *subjectManager) getCount(cnt *int64, _type string) error {
+func (m *subjectManager) getCount(count *int64, _type string) error {
 	query := `SELECT
 		COUNT(*)
 		FROM subject
 		WHERE type = ?`
-	return database.SqlxGet(m.DB, cnt, query, _type)
+	return database.SqlxGet(m.DB, count, query, _type)
 }
 
 func (m *subjectManager) bulkInsert(subjects []Subject) error {

--- a/pkg/database/dao/subject_relation.go
+++ b/pkg/database/dao/subject_relation.go
@@ -393,6 +393,7 @@ func (m *subjectRelationManager) updateExpiredAt(relations []SubjectRelationPKPo
 func (m *subjectRelationManager) listParentPKsBeforeExpiredAt(
 	expiredParentPKs *[]int64, parentPKs []int64, expiredAt int64,
 ) error {
+	// TODO: DISTINCT 大表很慢
 	query := `SELECT
 		DISTINCT parent_pk
 		FROM subject_relation

--- a/pkg/database/dao/subject_relation.go
+++ b/pkg/database/dao/subject_relation.go
@@ -163,9 +163,9 @@ func (m *subjectRelationManager) ListMember(parentPK int64) (members []SubjectRe
 
 // GetMemberCount ...
 func (m *subjectRelationManager) GetMemberCount(parentPK int64) (int64, error) {
-	var cnt int64
-	err := m.getMemberCount(&cnt, parentPK)
-	return cnt, err
+	var count int64
+	err := m.getMemberCount(&count, parentPK)
+	return count, err
 }
 
 // BulkDeleteByMembersWithTx ...
@@ -210,9 +210,9 @@ func (m *subjectRelationManager) UpdateExpiredAt(relations []SubjectRelationPKPo
 func (m *subjectRelationManager) GetMemberCountBeforeExpiredAt(
 	parentPK int64, expiredAt int64,
 ) (int64, error) {
-	var cnt int64
-	err := m.getMemberCountBeforeExpiredAt(&cnt, parentPK, expiredAt)
-	return cnt, err
+	var count int64
+	err := m.getMemberCountBeforeExpiredAt(&count, parentPK, expiredAt)
+	return count, err
 }
 
 // ListPagingMemberBeforeExpiredAt ...
@@ -339,23 +339,23 @@ func (m *subjectRelationManager) selectMembers(
 	return database.SqlxSelect(m.DB, members, query, parentPK)
 }
 
-func (m *subjectRelationManager) getMemberCount(cnt *int64, parentPK int64) error {
+func (m *subjectRelationManager) getMemberCount(count *int64, parentPK int64) error {
 	query := `SELECT
 		COUNT(*)
 		FROM subject_relation
 		WHERE parent_pk = ?`
-	return database.SqlxGet(m.DB, cnt, query, parentPK)
+	return database.SqlxGet(m.DB, count, query, parentPK)
 }
 
 func (m *subjectRelationManager) getMemberCountBeforeExpiredAt(
-	cnt *int64, parentPK int64, expiredAt int64,
+	count *int64, parentPK int64, expiredAt int64,
 ) error {
 	query := `SELECT
 		COUNT(*)
 		FROM subject_relation
 		WHERE parent_pk = ?
 		AND policy_expired_at < ?`
-	return database.SqlxGet(m.DB, cnt, query, parentPK, expiredAt)
+	return database.SqlxGet(m.DB, count, query, parentPK, expiredAt)
 }
 
 func (m *subjectRelationManager) bulkDeleteByMembersWithTx(

--- a/pkg/database/edao/mock/app_secret.go
+++ b/pkg/database/edao/mock/app_secret.go
@@ -5,34 +5,35 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockAppSecretManager is a mock of AppSecretManager interface
+// MockAppSecretManager is a mock of AppSecretManager interface.
 type MockAppSecretManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockAppSecretManagerMockRecorder
 }
 
-// MockAppSecretManagerMockRecorder is the mock recorder for MockAppSecretManager
+// MockAppSecretManagerMockRecorder is the mock recorder for MockAppSecretManager.
 type MockAppSecretManagerMockRecorder struct {
 	mock *MockAppSecretManager
 }
 
-// NewMockAppSecretManager creates a new mock instance
+// NewMockAppSecretManager creates a new mock instance.
 func NewMockAppSecretManager(ctrl *gomock.Controller) *MockAppSecretManager {
 	mock := &MockAppSecretManager{ctrl: ctrl}
 	mock.recorder = &MockAppSecretManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAppSecretManager) EXPECT() *MockAppSecretManagerMockRecorder {
 	return m.recorder
 }
 
-// Exists mocks base method
+// Exists mocks base method.
 func (m *MockAppSecretManager) Exists(appCode, appSecret string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", appCode, appSecret)
@@ -41,7 +42,7 @@ func (m *MockAppSecretManager) Exists(appCode, appSecret string) (bool, error) {
 	return ret0, ret1
 }
 
-// Exists indicates an expected call of Exists
+// Exists indicates an expected call of Exists.
 func (mr *MockAppSecretManagerMockRecorder) Exists(appCode, appSecret interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockAppSecretManager)(nil).Exists), appCode, appSecret)

--- a/pkg/database/sdao/mock/saas_action.go
+++ b/pkg/database/sdao/mock/saas_action.go
@@ -5,36 +5,65 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSaaSActionManager is a mock of SaaSActionManager interface
+// MockSaaSActionManager is a mock of SaaSActionManager interface.
 type MockSaaSActionManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSActionManagerMockRecorder
 }
 
-// MockSaaSActionManagerMockRecorder is the mock recorder for MockSaaSActionManager
+// MockSaaSActionManagerMockRecorder is the mock recorder for MockSaaSActionManager.
 type MockSaaSActionManagerMockRecorder struct {
 	mock *MockSaaSActionManager
 }
 
-// NewMockSaaSActionManager creates a new mock instance
+// NewMockSaaSActionManager creates a new mock instance.
 func NewMockSaaSActionManager(ctrl *gomock.Controller) *MockSaaSActionManager {
 	mock := &MockSaaSActionManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSActionManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSActionManager) EXPECT() *MockSaaSActionManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// BulkCreateWithTx mocks base method.
+func (m *MockSaaSActionManager) BulkCreateWithTx(tx *sqlx.Tx, saasActions []sdao.SaaSAction) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasActions)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
+func (mr *MockSaaSActionManagerMockRecorder) BulkCreateWithTx(tx, saasActions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSActionManager)(nil).BulkCreateWithTx), tx, saasActions)
+}
+
+// BulkDeleteWithTx mocks base method.
+func (m *MockSaaSActionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockSaaSActionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSActionManager)(nil).BulkDeleteWithTx), tx, system, ids)
+}
+
+// Get mocks base method.
 func (m *MockSaaSActionManager) Get(system, actionID string) (sdao.SaaSAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, actionID)
@@ -43,13 +72,13 @@ func (m *MockSaaSActionManager) Get(system, actionID string) (sdao.SaaSAction, e
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSaaSActionManagerMockRecorder) Get(system, actionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSaaSActionManager)(nil).Get), system, actionID)
 }
 
-// ListBySystem mocks base method
+// ListBySystem mocks base method.
 func (m *MockSaaSActionManager) ListBySystem(system string) ([]sdao.SaaSAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBySystem", system)
@@ -58,27 +87,13 @@ func (m *MockSaaSActionManager) ListBySystem(system string) ([]sdao.SaaSAction, 
 	return ret0, ret1
 }
 
-// ListBySystem indicates an expected call of ListBySystem
+// ListBySystem indicates an expected call of ListBySystem.
 func (mr *MockSaaSActionManagerMockRecorder) ListBySystem(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockSaaSActionManager)(nil).ListBySystem), system)
 }
 
-// BulkCreateWithTx mocks base method
-func (m *MockSaaSActionManager) BulkCreateWithTx(tx *sqlx.Tx, saasActions []sdao.SaaSAction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasActions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
-func (mr *MockSaaSActionManagerMockRecorder) BulkCreateWithTx(tx, saasActions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSActionManager)(nil).BulkCreateWithTx), tx, saasActions)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockSaaSActionManager) Update(tx *sqlx.Tx, system, actionID string, saasAction sdao.SaaSAction) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", tx, system, actionID, saasAction)
@@ -86,22 +101,8 @@ func (m *MockSaaSActionManager) Update(tx *sqlx.Tx, system, actionID string, saa
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockSaaSActionManagerMockRecorder) Update(tx, system, actionID, saasAction interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSActionManager)(nil).Update), tx, system, actionID, saasAction)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockSaaSActionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockSaaSActionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSActionManager)(nil).BulkDeleteWithTx), tx, system, ids)
 }

--- a/pkg/database/sdao/mock/saas_action_resource_type.go
+++ b/pkg/database/sdao/mock/saas_action_resource_type.go
@@ -5,51 +5,65 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSaaSActionResourceTypeManager is a mock of SaaSActionResourceTypeManager interface
+// MockSaaSActionResourceTypeManager is a mock of SaaSActionResourceTypeManager interface.
 type MockSaaSActionResourceTypeManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSActionResourceTypeManagerMockRecorder
 }
 
-// MockSaaSActionResourceTypeManagerMockRecorder is the mock recorder for MockSaaSActionResourceTypeManager
+// MockSaaSActionResourceTypeManagerMockRecorder is the mock recorder for MockSaaSActionResourceTypeManager.
 type MockSaaSActionResourceTypeManagerMockRecorder struct {
 	mock *MockSaaSActionResourceTypeManager
 }
 
-// NewMockSaaSActionResourceTypeManager creates a new mock instance
+// NewMockSaaSActionResourceTypeManager creates a new mock instance.
 func NewMockSaaSActionResourceTypeManager(ctrl *gomock.Controller) *MockSaaSActionResourceTypeManager {
 	mock := &MockSaaSActionResourceTypeManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSActionResourceTypeManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSActionResourceTypeManager) EXPECT() *MockSaaSActionResourceTypeManagerMockRecorder {
 	return m.recorder
 }
 
-// ListByActionSystem mocks base method
-func (m *MockSaaSActionResourceTypeManager) ListByActionSystem(actionSystem string) ([]sdao.SaaSActionResourceType, error) {
+// BulkCreateWithTx mocks base method.
+func (m *MockSaaSActionResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, saasActionResourceTypes []sdao.SaaSActionResourceType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByActionSystem", actionSystem)
-	ret0, _ := ret[0].([]sdao.SaaSActionResourceType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasActionResourceTypes)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// ListByActionSystem indicates an expected call of ListByActionSystem
-func (mr *MockSaaSActionResourceTypeManagerMockRecorder) ListByActionSystem(actionSystem interface{}) *gomock.Call {
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
+func (mr *MockSaaSActionResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, saasActionResourceTypes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByActionSystem", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).ListByActionSystem), actionSystem)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).BulkCreateWithTx), tx, saasActionResourceTypes)
 }
 
-// ListByActionID mocks base method
+// BulkDeleteWithTx mocks base method.
+func (m *MockSaaSActionResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, actionSystem string, actionIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, actionSystem, actionIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockSaaSActionResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, actionSystem, actionIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).BulkDeleteWithTx), tx, actionSystem, actionIDs)
+}
+
+// ListByActionID mocks base method.
 func (m *MockSaaSActionResourceTypeManager) ListByActionID(system, actionID string) ([]sdao.SaaSActionResourceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByActionID", system, actionID)
@@ -58,36 +72,23 @@ func (m *MockSaaSActionResourceTypeManager) ListByActionID(system, actionID stri
 	return ret0, ret1
 }
 
-// ListByActionID indicates an expected call of ListByActionID
+// ListByActionID indicates an expected call of ListByActionID.
 func (mr *MockSaaSActionResourceTypeManagerMockRecorder) ListByActionID(system, actionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByActionID", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).ListByActionID), system, actionID)
 }
 
-// BulkCreateWithTx mocks base method
-func (m *MockSaaSActionResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, saasActionResourceTypes []sdao.SaaSActionResourceType) error {
+// ListByActionSystem mocks base method.
+func (m *MockSaaSActionResourceTypeManager) ListByActionSystem(actionSystem string) ([]sdao.SaaSActionResourceType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasActionResourceTypes)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ListByActionSystem", actionSystem)
+	ret0, _ := ret[0].([]sdao.SaaSActionResourceType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
-func (mr *MockSaaSActionResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, saasActionResourceTypes interface{}) *gomock.Call {
+// ListByActionSystem indicates an expected call of ListByActionSystem.
+func (mr *MockSaaSActionResourceTypeManagerMockRecorder) ListByActionSystem(actionSystem interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).BulkCreateWithTx), tx, saasActionResourceTypes)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockSaaSActionResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, actionSystem string, actionIDs []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, actionSystem, actionIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockSaaSActionResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, actionSystem, actionIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).BulkDeleteWithTx), tx, actionSystem, actionIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByActionSystem", reflect.TypeOf((*MockSaaSActionResourceTypeManager)(nil).ListByActionSystem), actionSystem)
 }

--- a/pkg/database/sdao/mock/saas_instance_selection.go
+++ b/pkg/database/sdao/mock/saas_instance_selection.go
@@ -5,36 +5,65 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSaaSInstanceSelectionManager is a mock of SaaSInstanceSelectionManager interface
+// MockSaaSInstanceSelectionManager is a mock of SaaSInstanceSelectionManager interface.
 type MockSaaSInstanceSelectionManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSInstanceSelectionManagerMockRecorder
 }
 
-// MockSaaSInstanceSelectionManagerMockRecorder is the mock recorder for MockSaaSInstanceSelectionManager
+// MockSaaSInstanceSelectionManagerMockRecorder is the mock recorder for MockSaaSInstanceSelectionManager.
 type MockSaaSInstanceSelectionManagerMockRecorder struct {
 	mock *MockSaaSInstanceSelectionManager
 }
 
-// NewMockSaaSInstanceSelectionManager creates a new mock instance
+// NewMockSaaSInstanceSelectionManager creates a new mock instance.
 func NewMockSaaSInstanceSelectionManager(ctrl *gomock.Controller) *MockSaaSInstanceSelectionManager {
 	mock := &MockSaaSInstanceSelectionManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSInstanceSelectionManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSInstanceSelectionManager) EXPECT() *MockSaaSInstanceSelectionManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// BulkCreateWithTx mocks base method.
+func (m *MockSaaSInstanceSelectionManager) BulkCreateWithTx(tx *sqlx.Tx, saasInstanceSelections []sdao.SaaSInstanceSelection) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasInstanceSelections)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
+func (mr *MockSaaSInstanceSelectionManagerMockRecorder) BulkCreateWithTx(tx, saasInstanceSelections interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).BulkCreateWithTx), tx, saasInstanceSelections)
+}
+
+// BulkDeleteWithTx mocks base method.
+func (m *MockSaaSInstanceSelectionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
+func (mr *MockSaaSInstanceSelectionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).BulkDeleteWithTx), tx, system, ids)
+}
+
+// Get mocks base method.
 func (m *MockSaaSInstanceSelectionManager) Get(system, id string) (sdao.SaaSInstanceSelection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, id)
@@ -43,13 +72,13 @@ func (m *MockSaaSInstanceSelectionManager) Get(system, id string) (sdao.SaaSInst
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSaaSInstanceSelectionManagerMockRecorder) Get(system, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).Get), system, id)
 }
 
-// ListBySystem mocks base method
+// ListBySystem mocks base method.
 func (m *MockSaaSInstanceSelectionManager) ListBySystem(system string) ([]sdao.SaaSInstanceSelection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBySystem", system)
@@ -58,27 +87,13 @@ func (m *MockSaaSInstanceSelectionManager) ListBySystem(system string) ([]sdao.S
 	return ret0, ret1
 }
 
-// ListBySystem indicates an expected call of ListBySystem
+// ListBySystem indicates an expected call of ListBySystem.
 func (mr *MockSaaSInstanceSelectionManagerMockRecorder) ListBySystem(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).ListBySystem), system)
 }
 
-// BulkCreateWithTx mocks base method
-func (m *MockSaaSInstanceSelectionManager) BulkCreateWithTx(tx *sqlx.Tx, saasInstanceSelections []sdao.SaaSInstanceSelection) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasInstanceSelections)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
-func (mr *MockSaaSInstanceSelectionManagerMockRecorder) BulkCreateWithTx(tx, saasInstanceSelections interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).BulkCreateWithTx), tx, saasInstanceSelections)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockSaaSInstanceSelectionManager) Update(system, instanceSelectionID string, sis sdao.SaaSInstanceSelection) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", system, instanceSelectionID, sis)
@@ -86,22 +101,8 @@ func (m *MockSaaSInstanceSelectionManager) Update(system, instanceSelectionID st
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockSaaSInstanceSelectionManagerMockRecorder) Update(system, instanceSelectionID, sis interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).Update), system, instanceSelectionID, sis)
-}
-
-// BulkDeleteWithTx mocks base method
-func (m *MockSaaSInstanceSelectionManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
-func (mr *MockSaaSInstanceSelectionManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSInstanceSelectionManager)(nil).BulkDeleteWithTx), tx, system, ids)
 }

--- a/pkg/database/sdao/mock/saas_resource_type.go
+++ b/pkg/database/sdao/mock/saas_resource_type.go
@@ -5,51 +5,37 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSaaSResourceTypeManager is a mock of SaaSResourceTypeManager interface
+// MockSaaSResourceTypeManager is a mock of SaaSResourceTypeManager interface.
 type MockSaaSResourceTypeManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSResourceTypeManagerMockRecorder
 }
 
-// MockSaaSResourceTypeManagerMockRecorder is the mock recorder for MockSaaSResourceTypeManager
+// MockSaaSResourceTypeManagerMockRecorder is the mock recorder for MockSaaSResourceTypeManager.
 type MockSaaSResourceTypeManagerMockRecorder struct {
 	mock *MockSaaSResourceTypeManager
 }
 
-// NewMockSaaSResourceTypeManager creates a new mock instance
+// NewMockSaaSResourceTypeManager creates a new mock instance.
 func NewMockSaaSResourceTypeManager(ctrl *gomock.Controller) *MockSaaSResourceTypeManager {
 	mock := &MockSaaSResourceTypeManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSResourceTypeManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSResourceTypeManager) EXPECT() *MockSaaSResourceTypeManagerMockRecorder {
 	return m.recorder
 }
 
-// ListBySystem mocks base method
-func (m *MockSaaSResourceTypeManager) ListBySystem(system string) ([]sdao.SaaSResourceType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySystem", system)
-	ret0, _ := ret[0].([]sdao.SaaSResourceType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySystem indicates an expected call of ListBySystem
-func (mr *MockSaaSResourceTypeManagerMockRecorder) ListBySystem(system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).ListBySystem), system)
-}
-
-// BulkCreateWithTx mocks base method
+// BulkCreateWithTx mocks base method.
 func (m *MockSaaSResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, saasResourceTypes []sdao.SaaSResourceType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreateWithTx", tx, saasResourceTypes)
@@ -57,27 +43,13 @@ func (m *MockSaaSResourceTypeManager) BulkCreateWithTx(tx *sqlx.Tx, saasResource
 	return ret0
 }
 
-// BulkCreateWithTx indicates an expected call of BulkCreateWithTx
+// BulkCreateWithTx indicates an expected call of BulkCreateWithTx.
 func (mr *MockSaaSResourceTypeManagerMockRecorder) BulkCreateWithTx(tx, saasResourceTypes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateWithTx", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).BulkCreateWithTx), tx, saasResourceTypes)
 }
 
-// Update mocks base method
-func (m *MockSaaSResourceTypeManager) Update(system, resourceTypeID string, sys sdao.SaaSResourceType) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", system, resourceTypeID, sys)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update
-func (mr *MockSaaSResourceTypeManagerMockRecorder) Update(system, resourceTypeID, sys interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).Update), system, resourceTypeID, sys)
-}
-
-// BulkDeleteWithTx mocks base method
+// BulkDeleteWithTx mocks base method.
 func (m *MockSaaSResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, system string, ids []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteWithTx", tx, system, ids)
@@ -85,13 +57,13 @@ func (m *MockSaaSResourceTypeManager) BulkDeleteWithTx(tx *sqlx.Tx, system strin
 	return ret0
 }
 
-// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx
+// BulkDeleteWithTx indicates an expected call of BulkDeleteWithTx.
 func (mr *MockSaaSResourceTypeManagerMockRecorder) BulkDeleteWithTx(tx, system, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteWithTx", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).BulkDeleteWithTx), tx, system, ids)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockSaaSResourceTypeManager) Get(system, resourceTypeID string) (sdao.SaaSResourceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, resourceTypeID)
@@ -100,8 +72,37 @@ func (m *MockSaaSResourceTypeManager) Get(system, resourceTypeID string) (sdao.S
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSaaSResourceTypeManagerMockRecorder) Get(system, resourceTypeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).Get), system, resourceTypeID)
+}
+
+// ListBySystem mocks base method.
+func (m *MockSaaSResourceTypeManager) ListBySystem(system string) ([]sdao.SaaSResourceType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySystem", system)
+	ret0, _ := ret[0].([]sdao.SaaSResourceType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySystem indicates an expected call of ListBySystem.
+func (mr *MockSaaSResourceTypeManagerMockRecorder) ListBySystem(system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).ListBySystem), system)
+}
+
+// Update mocks base method.
+func (m *MockSaaSResourceTypeManager) Update(system, resourceTypeID string, sys sdao.SaaSResourceType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", system, resourceTypeID, sys)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockSaaSResourceTypeManagerMockRecorder) Update(system, resourceTypeID, sys interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSResourceTypeManager)(nil).Update), system, resourceTypeID, sys)
 }

--- a/pkg/database/sdao/mock/saas_system.go
+++ b/pkg/database/sdao/mock/saas_system.go
@@ -5,36 +5,51 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	sqlx "github.com/jmoiron/sqlx"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 )
 
-// MockSaaSSystemManager is a mock of SaaSSystemManager interface
+// MockSaaSSystemManager is a mock of SaaSSystemManager interface.
 type MockSaaSSystemManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSSystemManagerMockRecorder
 }
 
-// MockSaaSSystemManagerMockRecorder is the mock recorder for MockSaaSSystemManager
+// MockSaaSSystemManagerMockRecorder is the mock recorder for MockSaaSSystemManager.
 type MockSaaSSystemManagerMockRecorder struct {
 	mock *MockSaaSSystemManager
 }
 
-// NewMockSaaSSystemManager creates a new mock instance
+// NewMockSaaSSystemManager creates a new mock instance.
 func NewMockSaaSSystemManager(ctrl *gomock.Controller) *MockSaaSSystemManager {
 	mock := &MockSaaSSystemManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSSystemManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSSystemManager) EXPECT() *MockSaaSSystemManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// CreateWithTx mocks base method.
+func (m *MockSaaSSystemManager) CreateWithTx(tx *sqlx.Tx, system sdao.SaaSSystem) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWithTx", tx, system)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateWithTx indicates an expected call of CreateWithTx.
+func (mr *MockSaaSSystemManagerMockRecorder) CreateWithTx(tx, system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithTx", reflect.TypeOf((*MockSaaSSystemManager)(nil).CreateWithTx), tx, system)
+}
+
+// Get mocks base method.
 func (m *MockSaaSSystemManager) Get(id string) (sdao.SaaSSystem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", id)
@@ -43,13 +58,13 @@ func (m *MockSaaSSystemManager) Get(id string) (sdao.SaaSSystem, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSaaSSystemManagerMockRecorder) Get(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSaaSSystemManager)(nil).Get), id)
 }
 
-// ListAll mocks base method
+// ListAll mocks base method.
 func (m *MockSaaSSystemManager) ListAll() ([]sdao.SaaSSystem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAll")
@@ -58,27 +73,13 @@ func (m *MockSaaSSystemManager) ListAll() ([]sdao.SaaSSystem, error) {
 	return ret0, ret1
 }
 
-// ListAll indicates an expected call of ListAll
+// ListAll indicates an expected call of ListAll.
 func (mr *MockSaaSSystemManagerMockRecorder) ListAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockSaaSSystemManager)(nil).ListAll))
 }
 
-// CreateWithTx mocks base method
-func (m *MockSaaSSystemManager) CreateWithTx(tx *sqlx.Tx, system sdao.SaaSSystem) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWithTx", tx, system)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateWithTx indicates an expected call of CreateWithTx
-func (mr *MockSaaSSystemManagerMockRecorder) CreateWithTx(tx, system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithTx", reflect.TypeOf((*MockSaaSSystemManager)(nil).CreateWithTx), tx, system)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockSaaSSystemManager) Update(id string, system sdao.SaaSSystem) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", id, system)
@@ -86,7 +87,7 @@ func (m *MockSaaSSystemManager) Update(id string, system sdao.SaaSSystem) error 
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockSaaSSystemManagerMockRecorder) Update(id, system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSSystemManager)(nil).Update), id, system)

--- a/pkg/database/sdao/mock/saas_system_config.go
+++ b/pkg/database/sdao/mock/saas_system_config.go
@@ -5,35 +5,50 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	sdao "iam/pkg/database/sdao"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSaaSSystemConfigManager is a mock of SaaSSystemConfigManager interface
+// MockSaaSSystemConfigManager is a mock of SaaSSystemConfigManager interface.
 type MockSaaSSystemConfigManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaaSSystemConfigManagerMockRecorder
 }
 
-// MockSaaSSystemConfigManagerMockRecorder is the mock recorder for MockSaaSSystemConfigManager
+// MockSaaSSystemConfigManagerMockRecorder is the mock recorder for MockSaaSSystemConfigManager.
 type MockSaaSSystemConfigManagerMockRecorder struct {
 	mock *MockSaaSSystemConfigManager
 }
 
-// NewMockSaaSSystemConfigManager creates a new mock instance
+// NewMockSaaSSystemConfigManager creates a new mock instance.
 func NewMockSaaSSystemConfigManager(ctrl *gomock.Controller) *MockSaaSSystemConfigManager {
 	mock := &MockSaaSSystemConfigManager{ctrl: ctrl}
 	mock.recorder = &MockSaaSSystemConfigManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaaSSystemConfigManager) EXPECT() *MockSaaSSystemConfigManagerMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Create mocks base method.
+func (m *MockSaaSSystemConfigManager) Create(systemConfig sdao.SaaSSystemConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", systemConfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockSaaSSystemConfigManagerMockRecorder) Create(systemConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSaaSSystemConfigManager)(nil).Create), systemConfig)
+}
+
+// Get mocks base method.
 func (m *MockSaaSSystemConfigManager) Get(system, name string) (sdao.SaaSSystemConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, name)
@@ -42,27 +57,13 @@ func (m *MockSaaSSystemConfigManager) Get(system, name string) (sdao.SaaSSystemC
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSaaSSystemConfigManagerMockRecorder) Get(system, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSaaSSystemConfigManager)(nil).Get), system, name)
 }
 
-// Create mocks base method
-func (m *MockSaaSSystemConfigManager) Create(systemConfig sdao.SaaSSystemConfig) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", systemConfig)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Create indicates an expected call of Create
-func (mr *MockSaaSSystemConfigManagerMockRecorder) Create(systemConfig interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSaaSSystemConfigManager)(nil).Create), systemConfig)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockSaaSSystemConfigManager) Update(systemConfig sdao.SaaSSystemConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", systemConfig)
@@ -70,7 +71,7 @@ func (m *MockSaaSSystemConfigManager) Update(systemConfig sdao.SaaSSystemConfig)
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockSaaSSystemConfigManagerMockRecorder) Update(systemConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSaaSSystemConfigManager)(nil).Update), systemConfig)

--- a/pkg/service/mock/action.go
+++ b/pkg/service/mock/action.go
@@ -5,50 +5,64 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockActionService is a mock of ActionService interface
+// MockActionService is a mock of ActionService interface.
 type MockActionService struct {
 	ctrl     *gomock.Controller
 	recorder *MockActionServiceMockRecorder
 }
 
-// MockActionServiceMockRecorder is the mock recorder for MockActionService
+// MockActionServiceMockRecorder is the mock recorder for MockActionService.
 type MockActionServiceMockRecorder struct {
 	mock *MockActionService
 }
 
-// NewMockActionService creates a new mock instance
+// NewMockActionService creates a new mock instance.
 func NewMockActionService(ctrl *gomock.Controller) *MockActionService {
 	mock := &MockActionService{ctrl: ctrl}
 	mock.recorder = &MockActionServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockActionService) EXPECT() *MockActionServiceMockRecorder {
 	return m.recorder
 }
 
-// GetActionPK mocks base method
-func (m *MockActionService) GetActionPK(system, id string) (int64, error) {
+// BulkCreate mocks base method.
+func (m *MockActionService) BulkCreate(system string, actions []types.Action) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActionPK", system, id)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "BulkCreate", system, actions)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetActionPK indicates an expected call of GetActionPK
-func (mr *MockActionServiceMockRecorder) GetActionPK(system, id interface{}) *gomock.Call {
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockActionServiceMockRecorder) BulkCreate(system, actions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionPK", reflect.TypeOf((*MockActionService)(nil).GetActionPK), system, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockActionService)(nil).BulkCreate), system, actions)
 }
 
-// Get mocks base method
+// BulkDelete mocks base method.
+func (m *MockActionService) BulkDelete(system string, actionIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDelete", system, actionIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDelete indicates an expected call of BulkDelete.
+func (mr *MockActionServiceMockRecorder) BulkDelete(system, actionIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockActionService)(nil).BulkDelete), system, actionIDs)
+}
+
+// Get mocks base method.
 func (m *MockActionService) Get(system, id string) (types.Action, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, id)
@@ -57,70 +71,28 @@ func (m *MockActionService) Get(system, id string) (types.Action, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockActionServiceMockRecorder) Get(system, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockActionService)(nil).Get), system, id)
 }
 
-// ListBySystem mocks base method
-func (m *MockActionService) ListBySystem(system string) ([]types.Action, error) {
+// GetActionPK mocks base method.
+func (m *MockActionService) GetActionPK(system, id string) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySystem", system)
-	ret0, _ := ret[0].([]types.Action)
+	ret := m.ctrl.Call(m, "GetActionPK", system, id)
+	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListBySystem indicates an expected call of ListBySystem
-func (mr *MockActionServiceMockRecorder) ListBySystem(system interface{}) *gomock.Call {
+// GetActionPK indicates an expected call of GetActionPK.
+func (mr *MockActionServiceMockRecorder) GetActionPK(system, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockActionService)(nil).ListBySystem), system)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionPK", reflect.TypeOf((*MockActionService)(nil).GetActionPK), system, id)
 }
 
-// BulkCreate mocks base method
-func (m *MockActionService) BulkCreate(system string, actions []types.Action) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", system, actions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockActionServiceMockRecorder) BulkCreate(system, actions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockActionService)(nil).BulkCreate), system, actions)
-}
-
-// Update mocks base method
-func (m *MockActionService) Update(system, actionID string, action types.Action) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", system, actionID, action)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update
-func (mr *MockActionServiceMockRecorder) Update(system, actionID, action interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockActionService)(nil).Update), system, actionID, action)
-}
-
-// BulkDelete mocks base method
-func (m *MockActionService) BulkDelete(system string, actionIDs []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDelete", system, actionIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDelete indicates an expected call of BulkDelete
-func (mr *MockActionServiceMockRecorder) BulkDelete(system, actionIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockActionService)(nil).BulkDelete), system, actionIDs)
-}
-
-// GetThinActionByPK mocks base method
+// GetThinActionByPK mocks base method.
 func (m *MockActionService) GetThinActionByPK(pk int64) (types.ThinAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetThinActionByPK", pk)
@@ -129,88 +101,13 @@ func (m *MockActionService) GetThinActionByPK(pk int64) (types.ThinAction, error
 	return ret0, ret1
 }
 
-// GetThinActionByPK indicates an expected call of GetThinActionByPK
+// GetThinActionByPK indicates an expected call of GetThinActionByPK.
 func (mr *MockActionServiceMockRecorder) GetThinActionByPK(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThinActionByPK", reflect.TypeOf((*MockActionService)(nil).GetThinActionByPK), pk)
 }
 
-// ListThinActionByPKs mocks base method
-func (m *MockActionService) ListThinActionByPKs(pks []int64) ([]types.ThinAction, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinActionByPKs", pks)
-	ret0, _ := ret[0].([]types.ThinAction)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinActionByPKs indicates an expected call of ListThinActionByPKs
-func (mr *MockActionServiceMockRecorder) ListThinActionByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionByPKs", reflect.TypeOf((*MockActionService)(nil).ListThinActionByPKs), pks)
-}
-
-// ListThinActionBySystem mocks base method
-func (m *MockActionService) ListThinActionBySystem(system string) ([]types.ThinAction, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinActionBySystem", system)
-	ret0, _ := ret[0].([]types.ThinAction)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinActionBySystem indicates an expected call of ListThinActionBySystem
-func (mr *MockActionServiceMockRecorder) ListThinActionBySystem(system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionBySystem", reflect.TypeOf((*MockActionService)(nil).ListThinActionBySystem), system)
-}
-
-// ListThinActionResourceTypes mocks base method
-func (m *MockActionService) ListThinActionResourceTypes(system, actionID string) ([]types.ThinActionResourceType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinActionResourceTypes", system, actionID)
-	ret0, _ := ret[0].([]types.ThinActionResourceType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinActionResourceTypes indicates an expected call of ListThinActionResourceTypes
-func (mr *MockActionServiceMockRecorder) ListThinActionResourceTypes(system, actionID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionResourceTypes", reflect.TypeOf((*MockActionService)(nil).ListThinActionResourceTypes), system, actionID)
-}
-
-// ListActionResourceTypeIDByResourceTypeSystem mocks base method
-func (m *MockActionService) ListActionResourceTypeIDByResourceTypeSystem(resourceTypeSystem string) ([]types.ActionResourceTypeID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListActionResourceTypeIDByResourceTypeSystem", resourceTypeSystem)
-	ret0, _ := ret[0].([]types.ActionResourceTypeID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListActionResourceTypeIDByResourceTypeSystem indicates an expected call of ListActionResourceTypeIDByResourceTypeSystem
-func (mr *MockActionServiceMockRecorder) ListActionResourceTypeIDByResourceTypeSystem(resourceTypeSystem interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionResourceTypeIDByResourceTypeSystem", reflect.TypeOf((*MockActionService)(nil).ListActionResourceTypeIDByResourceTypeSystem), resourceTypeSystem)
-}
-
-// ListActionResourceTypeIDByActionSystem mocks base method
-func (m *MockActionService) ListActionResourceTypeIDByActionSystem(actionSystem string) ([]types.ActionResourceTypeID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListActionResourceTypeIDByActionSystem", actionSystem)
-	ret0, _ := ret[0].([]types.ActionResourceTypeID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListActionResourceTypeIDByActionSystem indicates an expected call of ListActionResourceTypeIDByActionSystem
-func (mr *MockActionServiceMockRecorder) ListActionResourceTypeIDByActionSystem(actionSystem interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionResourceTypeIDByActionSystem", reflect.TypeOf((*MockActionService)(nil).ListActionResourceTypeIDByActionSystem), actionSystem)
-}
-
-// ListActionInstanceSelectionIDBySystem mocks base method
+// ListActionInstanceSelectionIDBySystem mocks base method.
 func (m *MockActionService) ListActionInstanceSelectionIDBySystem(system string) ([]types.ActionInstanceSelectionID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListActionInstanceSelectionIDBySystem", system)
@@ -219,8 +116,112 @@ func (m *MockActionService) ListActionInstanceSelectionIDBySystem(system string)
 	return ret0, ret1
 }
 
-// ListActionInstanceSelectionIDBySystem indicates an expected call of ListActionInstanceSelectionIDBySystem
+// ListActionInstanceSelectionIDBySystem indicates an expected call of ListActionInstanceSelectionIDBySystem.
 func (mr *MockActionServiceMockRecorder) ListActionInstanceSelectionIDBySystem(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionInstanceSelectionIDBySystem", reflect.TypeOf((*MockActionService)(nil).ListActionInstanceSelectionIDBySystem), system)
+}
+
+// ListActionResourceTypeIDByActionSystem mocks base method.
+func (m *MockActionService) ListActionResourceTypeIDByActionSystem(actionSystem string) ([]types.ActionResourceTypeID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActionResourceTypeIDByActionSystem", actionSystem)
+	ret0, _ := ret[0].([]types.ActionResourceTypeID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActionResourceTypeIDByActionSystem indicates an expected call of ListActionResourceTypeIDByActionSystem.
+func (mr *MockActionServiceMockRecorder) ListActionResourceTypeIDByActionSystem(actionSystem interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionResourceTypeIDByActionSystem", reflect.TypeOf((*MockActionService)(nil).ListActionResourceTypeIDByActionSystem), actionSystem)
+}
+
+// ListActionResourceTypeIDByResourceTypeSystem mocks base method.
+func (m *MockActionService) ListActionResourceTypeIDByResourceTypeSystem(resourceTypeSystem string) ([]types.ActionResourceTypeID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActionResourceTypeIDByResourceTypeSystem", resourceTypeSystem)
+	ret0, _ := ret[0].([]types.ActionResourceTypeID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActionResourceTypeIDByResourceTypeSystem indicates an expected call of ListActionResourceTypeIDByResourceTypeSystem.
+func (mr *MockActionServiceMockRecorder) ListActionResourceTypeIDByResourceTypeSystem(resourceTypeSystem interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionResourceTypeIDByResourceTypeSystem", reflect.TypeOf((*MockActionService)(nil).ListActionResourceTypeIDByResourceTypeSystem), resourceTypeSystem)
+}
+
+// ListBySystem mocks base method.
+func (m *MockActionService) ListBySystem(system string) ([]types.Action, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySystem", system)
+	ret0, _ := ret[0].([]types.Action)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySystem indicates an expected call of ListBySystem.
+func (mr *MockActionServiceMockRecorder) ListBySystem(system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockActionService)(nil).ListBySystem), system)
+}
+
+// ListThinActionByPKs mocks base method.
+func (m *MockActionService) ListThinActionByPKs(pks []int64) ([]types.ThinAction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinActionByPKs", pks)
+	ret0, _ := ret[0].([]types.ThinAction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinActionByPKs indicates an expected call of ListThinActionByPKs.
+func (mr *MockActionServiceMockRecorder) ListThinActionByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionByPKs", reflect.TypeOf((*MockActionService)(nil).ListThinActionByPKs), pks)
+}
+
+// ListThinActionBySystem mocks base method.
+func (m *MockActionService) ListThinActionBySystem(system string) ([]types.ThinAction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinActionBySystem", system)
+	ret0, _ := ret[0].([]types.ThinAction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinActionBySystem indicates an expected call of ListThinActionBySystem.
+func (mr *MockActionServiceMockRecorder) ListThinActionBySystem(system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionBySystem", reflect.TypeOf((*MockActionService)(nil).ListThinActionBySystem), system)
+}
+
+// ListThinActionResourceTypes mocks base method.
+func (m *MockActionService) ListThinActionResourceTypes(system, actionID string) ([]types.ThinActionResourceType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinActionResourceTypes", system, actionID)
+	ret0, _ := ret[0].([]types.ThinActionResourceType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinActionResourceTypes indicates an expected call of ListThinActionResourceTypes.
+func (mr *MockActionServiceMockRecorder) ListThinActionResourceTypes(system, actionID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinActionResourceTypes", reflect.TypeOf((*MockActionService)(nil).ListThinActionResourceTypes), system, actionID)
+}
+
+// Update mocks base method.
+func (m *MockActionService) Update(system, actionID string, action types.Action) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", system, actionID, action)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockActionServiceMockRecorder) Update(system, actionID, action interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockActionService)(nil).Update), system, actionID, action)
 }

--- a/pkg/service/mock/engine_policy.go
+++ b/pkg/service/mock/engine_policy.go
@@ -5,35 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEnginePolicyService is a mock of EnginePolicyService interface
+// MockEnginePolicyService is a mock of EnginePolicyService interface.
 type MockEnginePolicyService struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnginePolicyServiceMockRecorder
 }
 
-// MockEnginePolicyServiceMockRecorder is the mock recorder for MockEnginePolicyService
+// MockEnginePolicyServiceMockRecorder is the mock recorder for MockEnginePolicyService.
 type MockEnginePolicyServiceMockRecorder struct {
 	mock *MockEnginePolicyService
 }
 
-// NewMockEnginePolicyService creates a new mock instance
+// NewMockEnginePolicyService creates a new mock instance.
 func NewMockEnginePolicyService(ctrl *gomock.Controller) *MockEnginePolicyService {
 	mock := &MockEnginePolicyService{ctrl: ctrl}
 	mock.recorder = &MockEnginePolicyServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnginePolicyService) EXPECT() *MockEnginePolicyServiceMockRecorder {
 	return m.recorder
 }
 
-// GetMaxPKBeforeUpdatedAt mocks base method
+// GetMaxPKBeforeUpdatedAt mocks base method.
 func (m *MockEnginePolicyService) GetMaxPKBeforeUpdatedAt(updatedAt int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaxPKBeforeUpdatedAt", updatedAt)
@@ -42,28 +43,13 @@ func (m *MockEnginePolicyService) GetMaxPKBeforeUpdatedAt(updatedAt int64) (int6
 	return ret0, ret1
 }
 
-// GetMaxPKBeforeUpdatedAt indicates an expected call of GetMaxPKBeforeUpdatedAt
+// GetMaxPKBeforeUpdatedAt indicates an expected call of GetMaxPKBeforeUpdatedAt.
 func (mr *MockEnginePolicyServiceMockRecorder) GetMaxPKBeforeUpdatedAt(updatedAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxPKBeforeUpdatedAt", reflect.TypeOf((*MockEnginePolicyService)(nil).GetMaxPKBeforeUpdatedAt), updatedAt)
 }
 
-// ListPKBetweenUpdatedAt mocks base method
-func (m *MockEnginePolicyService) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt int64) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPKBetweenUpdatedAt", beginUpdatedAt, endUpdatedAt)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPKBetweenUpdatedAt indicates an expected call of ListPKBetweenUpdatedAt
-func (mr *MockEnginePolicyServiceMockRecorder) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPKBetweenUpdatedAt", reflect.TypeOf((*MockEnginePolicyService)(nil).ListPKBetweenUpdatedAt), beginUpdatedAt, endUpdatedAt)
-}
-
-// ListBetweenPK mocks base method
+// ListBetweenPK mocks base method.
 func (m *MockEnginePolicyService) ListBetweenPK(expiredAt, minPK, maxPK int64) ([]types.EngineQueryPolicy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBetweenPK", expiredAt, minPK, maxPK)
@@ -72,13 +58,13 @@ func (m *MockEnginePolicyService) ListBetweenPK(expiredAt, minPK, maxPK int64) (
 	return ret0, ret1
 }
 
-// ListBetweenPK indicates an expected call of ListBetweenPK
+// ListBetweenPK indicates an expected call of ListBetweenPK.
 func (mr *MockEnginePolicyServiceMockRecorder) ListBetweenPK(expiredAt, minPK, maxPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBetweenPK", reflect.TypeOf((*MockEnginePolicyService)(nil).ListBetweenPK), expiredAt, minPK, maxPK)
 }
 
-// ListByPKs mocks base method
+// ListByPKs mocks base method.
 func (m *MockEnginePolicyService) ListByPKs(pks []int64) ([]types.EngineQueryPolicy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByPKs", pks)
@@ -87,8 +73,23 @@ func (m *MockEnginePolicyService) ListByPKs(pks []int64) ([]types.EngineQueryPol
 	return ret0, ret1
 }
 
-// ListByPKs indicates an expected call of ListByPKs
+// ListByPKs indicates an expected call of ListByPKs.
 func (mr *MockEnginePolicyServiceMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockEnginePolicyService)(nil).ListByPKs), pks)
+}
+
+// ListPKBetweenUpdatedAt mocks base method.
+func (m *MockEnginePolicyService) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt int64) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPKBetweenUpdatedAt", beginUpdatedAt, endUpdatedAt)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPKBetweenUpdatedAt indicates an expected call of ListPKBetweenUpdatedAt.
+func (mr *MockEnginePolicyServiceMockRecorder) ListPKBetweenUpdatedAt(beginUpdatedAt, endUpdatedAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPKBetweenUpdatedAt", reflect.TypeOf((*MockEnginePolicyService)(nil).ListPKBetweenUpdatedAt), beginUpdatedAt, endUpdatedAt)
 }

--- a/pkg/service/mock/instance_selection.go
+++ b/pkg/service/mock/instance_selection.go
@@ -5,35 +5,64 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockInstanceSelectionService is a mock of InstanceSelectionService interface
+// MockInstanceSelectionService is a mock of InstanceSelectionService interface.
 type MockInstanceSelectionService struct {
 	ctrl     *gomock.Controller
 	recorder *MockInstanceSelectionServiceMockRecorder
 }
 
-// MockInstanceSelectionServiceMockRecorder is the mock recorder for MockInstanceSelectionService
+// MockInstanceSelectionServiceMockRecorder is the mock recorder for MockInstanceSelectionService.
 type MockInstanceSelectionServiceMockRecorder struct {
 	mock *MockInstanceSelectionService
 }
 
-// NewMockInstanceSelectionService creates a new mock instance
+// NewMockInstanceSelectionService creates a new mock instance.
 func NewMockInstanceSelectionService(ctrl *gomock.Controller) *MockInstanceSelectionService {
 	mock := &MockInstanceSelectionService{ctrl: ctrl}
 	mock.recorder = &MockInstanceSelectionServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInstanceSelectionService) EXPECT() *MockInstanceSelectionServiceMockRecorder {
 	return m.recorder
 }
 
-// ListBySystem mocks base method
+// BulkCreate mocks base method.
+func (m *MockInstanceSelectionService) BulkCreate(system string, instanceSelections []types.InstanceSelection) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreate", system, instanceSelections)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreate indicates an expected call of BulkCreate.
+func (mr *MockInstanceSelectionServiceMockRecorder) BulkCreate(system, instanceSelections interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockInstanceSelectionService)(nil).BulkCreate), system, instanceSelections)
+}
+
+// BulkDelete mocks base method.
+func (m *MockInstanceSelectionService) BulkDelete(system string, instanceSelectionIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDelete", system, instanceSelectionIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDelete indicates an expected call of BulkDelete.
+func (mr *MockInstanceSelectionServiceMockRecorder) BulkDelete(system, instanceSelectionIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockInstanceSelectionService)(nil).BulkDelete), system, instanceSelectionIDs)
+}
+
+// ListBySystem mocks base method.
 func (m *MockInstanceSelectionService) ListBySystem(system string) ([]types.InstanceSelection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBySystem", system)
@@ -42,27 +71,13 @@ func (m *MockInstanceSelectionService) ListBySystem(system string) ([]types.Inst
 	return ret0, ret1
 }
 
-// ListBySystem indicates an expected call of ListBySystem
+// ListBySystem indicates an expected call of ListBySystem.
 func (mr *MockInstanceSelectionServiceMockRecorder) ListBySystem(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockInstanceSelectionService)(nil).ListBySystem), system)
 }
 
-// BulkCreate mocks base method
-func (m *MockInstanceSelectionService) BulkCreate(system string, instanceSelections []types.InstanceSelection) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreate", system, instanceSelections)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreate indicates an expected call of BulkCreate
-func (mr *MockInstanceSelectionServiceMockRecorder) BulkCreate(system, instanceSelections interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockInstanceSelectionService)(nil).BulkCreate), system, instanceSelections)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockInstanceSelectionService) Update(system, instanceSelectionID string, instanceSelection types.InstanceSelection) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", system, instanceSelectionID, instanceSelection)
@@ -70,22 +85,8 @@ func (m *MockInstanceSelectionService) Update(system, instanceSelectionID string
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockInstanceSelectionServiceMockRecorder) Update(system, instanceSelectionID, instanceSelection interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInstanceSelectionService)(nil).Update), system, instanceSelectionID, instanceSelection)
-}
-
-// BulkDelete mocks base method
-func (m *MockInstanceSelectionService) BulkDelete(system string, instanceSelectionIDs []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDelete", system, instanceSelectionIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDelete indicates an expected call of BulkDelete
-func (mr *MockInstanceSelectionServiceMockRecorder) BulkDelete(system, instanceSelectionIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockInstanceSelectionService)(nil).BulkDelete), system, instanceSelectionIDs)
 }

--- a/pkg/service/mock/model_change_event.go
+++ b/pkg/service/mock/model_change_event.go
@@ -5,78 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockModelChangeEventService is a mock of ModelChangeEventService interface
+// MockModelChangeEventService is a mock of ModelChangeEventService interface.
 type MockModelChangeEventService struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelChangeEventServiceMockRecorder
 }
 
-// MockModelChangeEventServiceMockRecorder is the mock recorder for MockModelChangeEventService
+// MockModelChangeEventServiceMockRecorder is the mock recorder for MockModelChangeEventService.
 type MockModelChangeEventServiceMockRecorder struct {
 	mock *MockModelChangeEventService
 }
 
-// NewMockModelChangeEventService creates a new mock instance
+// NewMockModelChangeEventService creates a new mock instance.
 func NewMockModelChangeEventService(ctrl *gomock.Controller) *MockModelChangeEventService {
 	mock := &MockModelChangeEventService{ctrl: ctrl}
 	mock.recorder = &MockModelChangeEventServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelChangeEventService) EXPECT() *MockModelChangeEventServiceMockRecorder {
 	return m.recorder
 }
 
-// ListByStatus mocks base method
-func (m *MockModelChangeEventService) ListByStatus(status string, limit int64) ([]types.ModelChangeEvent, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByStatus", status, limit)
-	ret0, _ := ret[0].([]types.ModelChangeEvent)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByStatus indicates an expected call of ListByStatus
-func (mr *MockModelChangeEventServiceMockRecorder) ListByStatus(status, limit interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByStatus", reflect.TypeOf((*MockModelChangeEventService)(nil).ListByStatus), status, limit)
-}
-
-// UpdateStatusByPK mocks base method
-func (m *MockModelChangeEventService) UpdateStatusByPK(pk int64, status string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusByPK", pk, status)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateStatusByPK indicates an expected call of UpdateStatusByPK
-func (mr *MockModelChangeEventServiceMockRecorder) UpdateStatusByPK(pk, status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByPK", reflect.TypeOf((*MockModelChangeEventService)(nil).UpdateStatusByPK), pk, status)
-}
-
-// UpdateStatusByModel mocks base method
-func (m *MockModelChangeEventService) UpdateStatusByModel(eventType, modelType string, modelPK int64, status string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusByModel", eventType, modelType, modelPK, status)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateStatusByModel indicates an expected call of UpdateStatusByModel
-func (mr *MockModelChangeEventServiceMockRecorder) UpdateStatusByModel(eventType, modelType, modelPK, status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByModel", reflect.TypeOf((*MockModelChangeEventService)(nil).UpdateStatusByModel), eventType, modelType, modelPK, status)
-}
-
-// BulkCreate mocks base method
+// BulkCreate mocks base method.
 func (m *MockModelChangeEventService) BulkCreate(modelChangeEvents []types.ModelChangeEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreate", modelChangeEvents)
@@ -84,13 +42,27 @@ func (m *MockModelChangeEventService) BulkCreate(modelChangeEvents []types.Model
 	return ret0
 }
 
-// BulkCreate indicates an expected call of BulkCreate
+// BulkCreate indicates an expected call of BulkCreate.
 func (mr *MockModelChangeEventServiceMockRecorder) BulkCreate(modelChangeEvents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockModelChangeEventService)(nil).BulkCreate), modelChangeEvents)
 }
 
-// ExistByTypeModel mocks base method
+// DeleteByStatus mocks base method.
+func (m *MockModelChangeEventService) DeleteByStatus(status string, beforeUpdatedAt, limit int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByStatus", status, beforeUpdatedAt, limit)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByStatus indicates an expected call of DeleteByStatus.
+func (mr *MockModelChangeEventServiceMockRecorder) DeleteByStatus(status, beforeUpdatedAt, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByStatus", reflect.TypeOf((*MockModelChangeEventService)(nil).DeleteByStatus), status, beforeUpdatedAt, limit)
+}
+
+// ExistByTypeModel mocks base method.
 func (m *MockModelChangeEventService) ExistByTypeModel(eventType, status, modelType string, modelPK int64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExistByTypeModel", eventType, status, modelType, modelPK)
@@ -99,22 +71,51 @@ func (m *MockModelChangeEventService) ExistByTypeModel(eventType, status, modelT
 	return ret0, ret1
 }
 
-// ExistByTypeModel indicates an expected call of ExistByTypeModel
+// ExistByTypeModel indicates an expected call of ExistByTypeModel.
 func (mr *MockModelChangeEventServiceMockRecorder) ExistByTypeModel(eventType, status, modelType, modelPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistByTypeModel", reflect.TypeOf((*MockModelChangeEventService)(nil).ExistByTypeModel), eventType, status, modelType, modelPK)
 }
 
-// DeleteByStatus mocks base method
-func (m *MockModelChangeEventService) DeleteByStatus(status string, beforeUpdatedAt, limit int64) error {
+// ListByStatus mocks base method.
+func (m *MockModelChangeEventService) ListByStatus(status string, limit int64) ([]types.ModelChangeEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByStatus", status, beforeUpdatedAt, limit)
+	ret := m.ctrl.Call(m, "ListByStatus", status, limit)
+	ret0, _ := ret[0].([]types.ModelChangeEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByStatus indicates an expected call of ListByStatus.
+func (mr *MockModelChangeEventServiceMockRecorder) ListByStatus(status, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByStatus", reflect.TypeOf((*MockModelChangeEventService)(nil).ListByStatus), status, limit)
+}
+
+// UpdateStatusByModel mocks base method.
+func (m *MockModelChangeEventService) UpdateStatusByModel(eventType, modelType string, modelPK int64, status string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatusByModel", eventType, modelType, modelPK, status)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteByStatus indicates an expected call of DeleteByStatus
-func (mr *MockModelChangeEventServiceMockRecorder) DeleteByStatus(status, beforeUpdatedAt, limit interface{}) *gomock.Call {
+// UpdateStatusByModel indicates an expected call of UpdateStatusByModel.
+func (mr *MockModelChangeEventServiceMockRecorder) UpdateStatusByModel(eventType, modelType, modelPK, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByStatus", reflect.TypeOf((*MockModelChangeEventService)(nil).DeleteByStatus), status, beforeUpdatedAt, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByModel", reflect.TypeOf((*MockModelChangeEventService)(nil).UpdateStatusByModel), eventType, modelType, modelPK, status)
+}
+
+// UpdateStatusByPK mocks base method.
+func (m *MockModelChangeEventService) UpdateStatusByPK(pk int64, status string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatusByPK", pk, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStatusByPK indicates an expected call of UpdateStatusByPK.
+func (mr *MockModelChangeEventServiceMockRecorder) UpdateStatusByPK(pk, status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusByPK", reflect.TypeOf((*MockModelChangeEventService)(nil).UpdateStatusByPK), pk, status)
 }

--- a/pkg/service/mock/policy.go
+++ b/pkg/service/mock/policy.go
@@ -5,125 +5,37 @@
 package mock
 
 import (
-	set "github.com/TencentBlueKing/gopkg/collection/set"
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	set "github.com/TencentBlueKing/gopkg/collection/set"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockPolicyService is a mock of PolicyService interface
+// MockPolicyService is a mock of PolicyService interface.
 type MockPolicyService struct {
 	ctrl     *gomock.Controller
 	recorder *MockPolicyServiceMockRecorder
 }
 
-// MockPolicyServiceMockRecorder is the mock recorder for MockPolicyService
+// MockPolicyServiceMockRecorder is the mock recorder for MockPolicyService.
 type MockPolicyServiceMockRecorder struct {
 	mock *MockPolicyService
 }
 
-// NewMockPolicyService creates a new mock instance
+// NewMockPolicyService creates a new mock instance.
 func NewMockPolicyService(ctrl *gomock.Controller) *MockPolicyService {
 	mock := &MockPolicyService{ctrl: ctrl}
 	mock.recorder = &MockPolicyServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPolicyService) EXPECT() *MockPolicyServiceMockRecorder {
 	return m.recorder
 }
 
-// ListAuthBySubjectAction mocks base method
-func (m *MockPolicyService) ListAuthBySubjectAction(subjectPKs []int64, actionPK int64) ([]types.AuthPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuthBySubjectAction", subjectPKs, actionPK)
-	ret0, _ := ret[0].([]types.AuthPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAuthBySubjectAction indicates an expected call of ListAuthBySubjectAction
-func (mr *MockPolicyServiceMockRecorder) ListAuthBySubjectAction(subjectPKs, actionPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthBySubjectAction", reflect.TypeOf((*MockPolicyService)(nil).ListAuthBySubjectAction), subjectPKs, actionPK)
-}
-
-// ListExpressionByPKs mocks base method
-func (m *MockPolicyService) ListExpressionByPKs(pks []int64) ([]types.AuthExpression, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExpressionByPKs", pks)
-	ret0, _ := ret[0].([]types.AuthExpression)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListExpressionByPKs indicates an expected call of ListExpressionByPKs
-func (mr *MockPolicyServiceMockRecorder) ListExpressionByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpressionByPKs", reflect.TypeOf((*MockPolicyService)(nil).ListExpressionByPKs), pks)
-}
-
-// GetByActionTemplate mocks base method
-func (m *MockPolicyService) GetByActionTemplate(subjectPK, actionPK, templateID int64) (types.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByActionTemplate", subjectPK, actionPK, templateID)
-	ret0, _ := ret[0].(types.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByActionTemplate indicates an expected call of GetByActionTemplate
-func (mr *MockPolicyServiceMockRecorder) GetByActionTemplate(subjectPK, actionPK, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyService)(nil).GetByActionTemplate), subjectPK, actionPK, templateID)
-}
-
-// ListThinBySubjectActionTemplate mocks base method
-func (m *MockPolicyService) ListThinBySubjectActionTemplate(subjectPK int64, actionPKs []int64, templateID int64) ([]types.ThinPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinBySubjectActionTemplate", subjectPK, actionPKs, templateID)
-	ret0, _ := ret[0].([]types.ThinPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinBySubjectActionTemplate indicates an expected call of ListThinBySubjectActionTemplate
-func (mr *MockPolicyServiceMockRecorder) ListThinBySubjectActionTemplate(subjectPK, actionPKs, templateID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectActionTemplate", reflect.TypeOf((*MockPolicyService)(nil).ListThinBySubjectActionTemplate), subjectPK, actionPKs, templateID)
-}
-
-// ListThinBySubjectTemplateBeforeExpiredAt mocks base method
-func (m *MockPolicyService) ListThinBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt int64) ([]types.ThinPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinBySubjectTemplateBeforeExpiredAt", subjectPK, templateID, expiredAt)
-	ret0, _ := ret[0].([]types.ThinPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinBySubjectTemplateBeforeExpiredAt indicates an expected call of ListThinBySubjectTemplateBeforeExpiredAt
-func (mr *MockPolicyServiceMockRecorder) ListThinBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).ListThinBySubjectTemplateBeforeExpiredAt), subjectPK, templateID, expiredAt)
-}
-
-// UpdateExpiredAt mocks base method
-func (m *MockPolicyService) UpdateExpiredAt(policies []types.QueryPolicy) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateExpiredAt", policies)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateExpiredAt indicates an expected call of UpdateExpiredAt
-func (mr *MockPolicyServiceMockRecorder) UpdateExpiredAt(policies interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).UpdateExpiredAt), policies)
-}
-
-// AlterCustomPolicies mocks base method
+// AlterCustomPolicies mocks base method.
 func (m *MockPolicyService) AlterCustomPolicies(subjectPK int64, createPolicies, updatePolicies []types.Policy, deletePolicyIDs []int64, actionPKWithResourceTypeSet *set.Int64Set) (map[int64][]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AlterCustomPolicies", subjectPK, createPolicies, updatePolicies, deletePolicyIDs, actionPKWithResourceTypeSet)
@@ -132,41 +44,13 @@ func (m *MockPolicyService) AlterCustomPolicies(subjectPK int64, createPolicies,
 	return ret0, ret1
 }
 
-// AlterCustomPolicies indicates an expected call of AlterCustomPolicies
+// AlterCustomPolicies indicates an expected call of AlterCustomPolicies.
 func (mr *MockPolicyServiceMockRecorder) AlterCustomPolicies(subjectPK, createPolicies, updatePolicies, deletePolicyIDs, actionPKWithResourceTypeSet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlterCustomPolicies", reflect.TypeOf((*MockPolicyService)(nil).AlterCustomPolicies), subjectPK, createPolicies, updatePolicies, deletePolicyIDs, actionPKWithResourceTypeSet)
 }
 
-// DeleteByPKs mocks base method
-func (m *MockPolicyService) DeleteByPKs(subjectPK int64, pks []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByPKs", subjectPK, pks)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByPKs indicates an expected call of DeleteByPKs
-func (mr *MockPolicyServiceMockRecorder) DeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPKs", reflect.TypeOf((*MockPolicyService)(nil).DeleteByPKs), subjectPK, pks)
-}
-
-// DeleteByActionPK mocks base method
-func (m *MockPolicyService) DeleteByActionPK(actionPK int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByActionPK", actionPK)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByActionPK indicates an expected call of DeleteByActionPK
-func (mr *MockPolicyServiceMockRecorder) DeleteByActionPK(actionPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByActionPK", reflect.TypeOf((*MockPolicyService)(nil).DeleteByActionPK), actionPK)
-}
-
-// CreateAndDeleteTemplatePolicies mocks base method
+// CreateAndDeleteTemplatePolicies mocks base method.
 func (m *MockPolicyService) CreateAndDeleteTemplatePolicies(subjectPK, templateID int64, createPolicies []types.Policy, deletePolicyIDs []int64, actionPKWithResourceTypeSet *set.Int64Set) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAndDeleteTemplatePolicies", subjectPK, templateID, createPolicies, deletePolicyIDs, actionPKWithResourceTypeSet)
@@ -174,27 +58,41 @@ func (m *MockPolicyService) CreateAndDeleteTemplatePolicies(subjectPK, templateI
 	return ret0
 }
 
-// CreateAndDeleteTemplatePolicies indicates an expected call of CreateAndDeleteTemplatePolicies
+// CreateAndDeleteTemplatePolicies indicates an expected call of CreateAndDeleteTemplatePolicies.
 func (mr *MockPolicyServiceMockRecorder) CreateAndDeleteTemplatePolicies(subjectPK, templateID, createPolicies, deletePolicyIDs, actionPKWithResourceTypeSet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndDeleteTemplatePolicies", reflect.TypeOf((*MockPolicyService)(nil).CreateAndDeleteTemplatePolicies), subjectPK, templateID, createPolicies, deletePolicyIDs, actionPKWithResourceTypeSet)
 }
 
-// UpdateTemplatePolicies mocks base method
-func (m *MockPolicyService) UpdateTemplatePolicies(subjectPK int64, policies []types.Policy, actionPKWithResourceTypeSet *set.Int64Set) error {
+// DeleteByActionPK mocks base method.
+func (m *MockPolicyService) DeleteByActionPK(actionPK int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTemplatePolicies", subjectPK, policies, actionPKWithResourceTypeSet)
+	ret := m.ctrl.Call(m, "DeleteByActionPK", actionPK)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateTemplatePolicies indicates an expected call of UpdateTemplatePolicies
-func (mr *MockPolicyServiceMockRecorder) UpdateTemplatePolicies(subjectPK, policies, actionPKWithResourceTypeSet interface{}) *gomock.Call {
+// DeleteByActionPK indicates an expected call of DeleteByActionPK.
+func (mr *MockPolicyServiceMockRecorder) DeleteByActionPK(actionPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplatePolicies", reflect.TypeOf((*MockPolicyService)(nil).UpdateTemplatePolicies), subjectPK, policies, actionPKWithResourceTypeSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByActionPK", reflect.TypeOf((*MockPolicyService)(nil).DeleteByActionPK), actionPK)
 }
 
-// DeleteTemplatePolicies mocks base method
+// DeleteByPKs mocks base method.
+func (m *MockPolicyService) DeleteByPKs(subjectPK int64, pks []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByPKs", subjectPK, pks)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByPKs indicates an expected call of DeleteByPKs.
+func (mr *MockPolicyServiceMockRecorder) DeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPKs", reflect.TypeOf((*MockPolicyService)(nil).DeleteByPKs), subjectPK, pks)
+}
+
+// DeleteTemplatePolicies mocks base method.
 func (m *MockPolicyService) DeleteTemplatePolicies(subjectPK, templateID int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTemplatePolicies", subjectPK, templateID)
@@ -202,13 +100,27 @@ func (m *MockPolicyService) DeleteTemplatePolicies(subjectPK, templateID int64) 
 	return ret0
 }
 
-// DeleteTemplatePolicies indicates an expected call of DeleteTemplatePolicies
+// DeleteTemplatePolicies indicates an expected call of DeleteTemplatePolicies.
 func (mr *MockPolicyServiceMockRecorder) DeleteTemplatePolicies(subjectPK, templateID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplatePolicies", reflect.TypeOf((*MockPolicyService)(nil).DeleteTemplatePolicies), subjectPK, templateID)
 }
 
-// Get mocks base method
+// DeleteUnreferencedExpressions mocks base method.
+func (m *MockPolicyService) DeleteUnreferencedExpressions() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUnreferencedExpressions")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUnreferencedExpressions indicates an expected call of DeleteUnreferencedExpressions.
+func (mr *MockPolicyServiceMockRecorder) DeleteUnreferencedExpressions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnreferencedExpressions", reflect.TypeOf((*MockPolicyService)(nil).DeleteUnreferencedExpressions))
+}
+
+// Get mocks base method.
 func (m *MockPolicyService) Get(pk int64) (types.QueryPolicy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", pk)
@@ -217,28 +129,28 @@ func (m *MockPolicyService) Get(pk int64) (types.QueryPolicy, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockPolicyServiceMockRecorder) Get(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPolicyService)(nil).Get), pk)
 }
 
-// ListPagingQueryByActionBeforeExpiredAt mocks base method
-func (m *MockPolicyService) ListPagingQueryByActionBeforeExpiredAt(actionPK, expiredAt, offset, limit int64) ([]types.QueryPolicy, error) {
+// GetByActionTemplate mocks base method.
+func (m *MockPolicyService) GetByActionTemplate(subjectPK, actionPK, templateID int64) (types.Policy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingQueryByActionBeforeExpiredAt", actionPK, expiredAt, offset, limit)
-	ret0, _ := ret[0].([]types.QueryPolicy)
+	ret := m.ctrl.Call(m, "GetByActionTemplate", subjectPK, actionPK, templateID)
+	ret0, _ := ret[0].(types.Policy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListPagingQueryByActionBeforeExpiredAt indicates an expected call of ListPagingQueryByActionBeforeExpiredAt
-func (mr *MockPolicyServiceMockRecorder) ListPagingQueryByActionBeforeExpiredAt(actionPK, expiredAt, offset, limit interface{}) *gomock.Call {
+// GetByActionTemplate indicates an expected call of GetByActionTemplate.
+func (mr *MockPolicyServiceMockRecorder) GetByActionTemplate(subjectPK, actionPK, templateID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingQueryByActionBeforeExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).ListPagingQueryByActionBeforeExpiredAt), actionPK, expiredAt, offset, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByActionTemplate", reflect.TypeOf((*MockPolicyService)(nil).GetByActionTemplate), subjectPK, actionPK, templateID)
 }
 
-// GetCountByActionBeforeExpiredAt mocks base method
+// GetCountByActionBeforeExpiredAt mocks base method.
 func (m *MockPolicyService) GetCountByActionBeforeExpiredAt(actionPK, expiredAt int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCountByActionBeforeExpiredAt", actionPK, expiredAt)
@@ -247,28 +159,13 @@ func (m *MockPolicyService) GetCountByActionBeforeExpiredAt(actionPK, expiredAt 
 	return ret0, ret1
 }
 
-// GetCountByActionBeforeExpiredAt indicates an expected call of GetCountByActionBeforeExpiredAt
+// GetCountByActionBeforeExpiredAt indicates an expected call of GetCountByActionBeforeExpiredAt.
 func (mr *MockPolicyServiceMockRecorder) GetCountByActionBeforeExpiredAt(actionPK, expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCountByActionBeforeExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).GetCountByActionBeforeExpiredAt), actionPK, expiredAt)
 }
 
-// ListQueryByPKs mocks base method
-func (m *MockPolicyService) ListQueryByPKs(pks []int64) ([]types.QueryPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListQueryByPKs", pks)
-	ret0, _ := ret[0].([]types.QueryPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListQueryByPKs indicates an expected call of ListQueryByPKs
-func (mr *MockPolicyServiceMockRecorder) ListQueryByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQueryByPKs", reflect.TypeOf((*MockPolicyService)(nil).ListQueryByPKs), pks)
-}
-
-// HasAnyByActionPK mocks base method
+// HasAnyByActionPK mocks base method.
 func (m *MockPolicyService) HasAnyByActionPK(actionPK int64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasAnyByActionPK", actionPK)
@@ -277,22 +174,126 @@ func (m *MockPolicyService) HasAnyByActionPK(actionPK int64) (bool, error) {
 	return ret0, ret1
 }
 
-// HasAnyByActionPK indicates an expected call of HasAnyByActionPK
+// HasAnyByActionPK indicates an expected call of HasAnyByActionPK.
 func (mr *MockPolicyServiceMockRecorder) HasAnyByActionPK(actionPK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnyByActionPK", reflect.TypeOf((*MockPolicyService)(nil).HasAnyByActionPK), actionPK)
 }
 
-// DeleteUnreferencedExpressions mocks base method
-func (m *MockPolicyService) DeleteUnreferencedExpressions() error {
+// ListAuthBySubjectAction mocks base method.
+func (m *MockPolicyService) ListAuthBySubjectAction(subjectPKs []int64, actionPK int64) ([]types.AuthPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUnreferencedExpressions")
+	ret := m.ctrl.Call(m, "ListAuthBySubjectAction", subjectPKs, actionPK)
+	ret0, _ := ret[0].([]types.AuthPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAuthBySubjectAction indicates an expected call of ListAuthBySubjectAction.
+func (mr *MockPolicyServiceMockRecorder) ListAuthBySubjectAction(subjectPKs, actionPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthBySubjectAction", reflect.TypeOf((*MockPolicyService)(nil).ListAuthBySubjectAction), subjectPKs, actionPK)
+}
+
+// ListExpressionByPKs mocks base method.
+func (m *MockPolicyService) ListExpressionByPKs(pks []int64) ([]types.AuthExpression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExpressionByPKs", pks)
+	ret0, _ := ret[0].([]types.AuthExpression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExpressionByPKs indicates an expected call of ListExpressionByPKs.
+func (mr *MockPolicyServiceMockRecorder) ListExpressionByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpressionByPKs", reflect.TypeOf((*MockPolicyService)(nil).ListExpressionByPKs), pks)
+}
+
+// ListPagingQueryByActionBeforeExpiredAt mocks base method.
+func (m *MockPolicyService) ListPagingQueryByActionBeforeExpiredAt(actionPK, expiredAt, offset, limit int64) ([]types.QueryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPagingQueryByActionBeforeExpiredAt", actionPK, expiredAt, offset, limit)
+	ret0, _ := ret[0].([]types.QueryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPagingQueryByActionBeforeExpiredAt indicates an expected call of ListPagingQueryByActionBeforeExpiredAt.
+func (mr *MockPolicyServiceMockRecorder) ListPagingQueryByActionBeforeExpiredAt(actionPK, expiredAt, offset, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingQueryByActionBeforeExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).ListPagingQueryByActionBeforeExpiredAt), actionPK, expiredAt, offset, limit)
+}
+
+// ListQueryByPKs mocks base method.
+func (m *MockPolicyService) ListQueryByPKs(pks []int64) ([]types.QueryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListQueryByPKs", pks)
+	ret0, _ := ret[0].([]types.QueryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListQueryByPKs indicates an expected call of ListQueryByPKs.
+func (mr *MockPolicyServiceMockRecorder) ListQueryByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQueryByPKs", reflect.TypeOf((*MockPolicyService)(nil).ListQueryByPKs), pks)
+}
+
+// ListThinBySubjectActionTemplate mocks base method.
+func (m *MockPolicyService) ListThinBySubjectActionTemplate(subjectPK int64, actionPKs []int64, templateID int64) ([]types.ThinPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinBySubjectActionTemplate", subjectPK, actionPKs, templateID)
+	ret0, _ := ret[0].([]types.ThinPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinBySubjectActionTemplate indicates an expected call of ListThinBySubjectActionTemplate.
+func (mr *MockPolicyServiceMockRecorder) ListThinBySubjectActionTemplate(subjectPK, actionPKs, templateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectActionTemplate", reflect.TypeOf((*MockPolicyService)(nil).ListThinBySubjectActionTemplate), subjectPK, actionPKs, templateID)
+}
+
+// ListThinBySubjectTemplateBeforeExpiredAt mocks base method.
+func (m *MockPolicyService) ListThinBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt int64) ([]types.ThinPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinBySubjectTemplateBeforeExpiredAt", subjectPK, templateID, expiredAt)
+	ret0, _ := ret[0].([]types.ThinPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinBySubjectTemplateBeforeExpiredAt indicates an expected call of ListThinBySubjectTemplateBeforeExpiredAt.
+func (mr *MockPolicyServiceMockRecorder) ListThinBySubjectTemplateBeforeExpiredAt(subjectPK, templateID, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectTemplateBeforeExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).ListThinBySubjectTemplateBeforeExpiredAt), subjectPK, templateID, expiredAt)
+}
+
+// UpdateExpiredAt mocks base method.
+func (m *MockPolicyService) UpdateExpiredAt(policies []types.QueryPolicy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateExpiredAt", policies)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteUnreferencedExpressions indicates an expected call of DeleteUnreferencedExpressions
-func (mr *MockPolicyServiceMockRecorder) DeleteUnreferencedExpressions() *gomock.Call {
+// UpdateExpiredAt indicates an expected call of UpdateExpiredAt.
+func (mr *MockPolicyServiceMockRecorder) UpdateExpiredAt(policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnreferencedExpressions", reflect.TypeOf((*MockPolicyService)(nil).DeleteUnreferencedExpressions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExpiredAt", reflect.TypeOf((*MockPolicyService)(nil).UpdateExpiredAt), policies)
+}
+
+// UpdateTemplatePolicies mocks base method.
+func (m *MockPolicyService) UpdateTemplatePolicies(subjectPK int64, policies []types.Policy, actionPKWithResourceTypeSet *set.Int64Set) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTemplatePolicies", subjectPK, policies, actionPKWithResourceTypeSet)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateTemplatePolicies indicates an expected call of UpdateTemplatePolicies.
+func (mr *MockPolicyServiceMockRecorder) UpdateTemplatePolicies(subjectPK, policies, actionPKWithResourceTypeSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplatePolicies", reflect.TypeOf((*MockPolicyService)(nil).UpdateTemplatePolicies), subjectPK, policies, actionPKWithResourceTypeSet)
 }

--- a/pkg/service/mock/resource_type.go
+++ b/pkg/service/mock/resource_type.go
@@ -5,50 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockResourceTypeService is a mock of ResourceTypeService interface
+// MockResourceTypeService is a mock of ResourceTypeService interface.
 type MockResourceTypeService struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceTypeServiceMockRecorder
 }
 
-// MockResourceTypeServiceMockRecorder is the mock recorder for MockResourceTypeService
+// MockResourceTypeServiceMockRecorder is the mock recorder for MockResourceTypeService.
 type MockResourceTypeServiceMockRecorder struct {
 	mock *MockResourceTypeService
 }
 
-// NewMockResourceTypeService creates a new mock instance
+// NewMockResourceTypeService creates a new mock instance.
 func NewMockResourceTypeService(ctrl *gomock.Controller) *MockResourceTypeService {
 	mock := &MockResourceTypeService{ctrl: ctrl}
 	mock.recorder = &MockResourceTypeServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceTypeService) EXPECT() *MockResourceTypeServiceMockRecorder {
 	return m.recorder
 }
 
-// ListBySystem mocks base method
-func (m *MockResourceTypeService) ListBySystem(system string) ([]types.ResourceType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBySystem", system)
-	ret0, _ := ret[0].([]types.ResourceType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBySystem indicates an expected call of ListBySystem
-func (mr *MockResourceTypeServiceMockRecorder) ListBySystem(system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockResourceTypeService)(nil).ListBySystem), system)
-}
-
-// BulkCreate mocks base method
+// BulkCreate mocks base method.
 func (m *MockResourceTypeService) BulkCreate(system string, resourceTypes []types.ResourceType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreate", system, resourceTypes)
@@ -56,27 +42,13 @@ func (m *MockResourceTypeService) BulkCreate(system string, resourceTypes []type
 	return ret0
 }
 
-// BulkCreate indicates an expected call of BulkCreate
+// BulkCreate indicates an expected call of BulkCreate.
 func (mr *MockResourceTypeServiceMockRecorder) BulkCreate(system, resourceTypes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockResourceTypeService)(nil).BulkCreate), system, resourceTypes)
 }
 
-// Update mocks base method
-func (m *MockResourceTypeService) Update(system, resourceTypeID string, resourceType types.ResourceType) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", system, resourceTypeID, resourceType)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update
-func (mr *MockResourceTypeServiceMockRecorder) Update(system, resourceTypeID, resourceType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceTypeService)(nil).Update), system, resourceTypeID, resourceType)
-}
-
-// BulkDelete mocks base method
+// BulkDelete mocks base method.
 func (m *MockResourceTypeService) BulkDelete(system string, resourceTypeIDs []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDelete", system, resourceTypeIDs)
@@ -84,13 +56,13 @@ func (m *MockResourceTypeService) BulkDelete(system string, resourceTypeIDs []st
 	return ret0
 }
 
-// BulkDelete indicates an expected call of BulkDelete
+// BulkDelete indicates an expected call of BulkDelete.
 func (mr *MockResourceTypeServiceMockRecorder) BulkDelete(system, resourceTypeIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockResourceTypeService)(nil).BulkDelete), system, resourceTypeIDs)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockResourceTypeService) Get(system, id string) (types.ResourceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", system, id)
@@ -99,8 +71,37 @@ func (m *MockResourceTypeService) Get(system, id string) (types.ResourceType, er
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockResourceTypeServiceMockRecorder) Get(system, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockResourceTypeService)(nil).Get), system, id)
+}
+
+// ListBySystem mocks base method.
+func (m *MockResourceTypeService) ListBySystem(system string) ([]types.ResourceType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBySystem", system)
+	ret0, _ := ret[0].([]types.ResourceType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBySystem indicates an expected call of ListBySystem.
+func (mr *MockResourceTypeServiceMockRecorder) ListBySystem(system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBySystem", reflect.TypeOf((*MockResourceTypeService)(nil).ListBySystem), system)
+}
+
+// Update mocks base method.
+func (m *MockResourceTypeService) Update(system, resourceTypeID string, resourceType types.ResourceType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", system, resourceTypeID, resourceType)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockResourceTypeServiceMockRecorder) Update(system, resourceTypeID, resourceType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceTypeService)(nil).Update), system, resourceTypeID, resourceType)
 }

--- a/pkg/service/mock/subject.go
+++ b/pkg/service/mock/subject.go
@@ -5,125 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSubjectService is a mock of SubjectService interface
+// MockSubjectService is a mock of SubjectService interface.
 type MockSubjectService struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubjectServiceMockRecorder
 }
 
-// MockSubjectServiceMockRecorder is the mock recorder for MockSubjectService
+// MockSubjectServiceMockRecorder is the mock recorder for MockSubjectService.
 type MockSubjectServiceMockRecorder struct {
 	mock *MockSubjectService
 }
 
-// NewMockSubjectService creates a new mock instance
+// NewMockSubjectService creates a new mock instance.
 func NewMockSubjectService(ctrl *gomock.Controller) *MockSubjectService {
 	mock := &MockSubjectService{ctrl: ctrl}
 	mock.recorder = &MockSubjectServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubjectService) EXPECT() *MockSubjectServiceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
-func (m *MockSubjectService) Get(pk int64) (types.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", pk)
-	ret0, _ := ret[0].(types.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Get indicates an expected call of Get
-func (mr *MockSubjectServiceMockRecorder) Get(pk interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSubjectService)(nil).Get), pk)
-}
-
-// GetPK mocks base method
-func (m *MockSubjectService) GetPK(_type, id string) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPK", _type, id)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPK indicates an expected call of GetPK
-func (mr *MockSubjectServiceMockRecorder) GetPK(_type, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockSubjectService)(nil).GetPK), _type, id)
-}
-
-// GetCount mocks base method
-func (m *MockSubjectService) GetCount(_type string) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCount", _type)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCount indicates an expected call of GetCount
-func (mr *MockSubjectServiceMockRecorder) GetCount(_type interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCount", reflect.TypeOf((*MockSubjectService)(nil).GetCount), _type)
-}
-
-// ListPaging mocks base method
-func (m *MockSubjectService) ListPaging(_type string, limit, offset int64) ([]types.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPaging", _type, limit, offset)
-	ret0, _ := ret[0].([]types.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPaging indicates an expected call of ListPaging
-func (mr *MockSubjectServiceMockRecorder) ListPaging(_type, limit, offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaging", reflect.TypeOf((*MockSubjectService)(nil).ListPaging), _type, limit, offset)
-}
-
-// ListPKsBySubjects mocks base method
-func (m *MockSubjectService) ListPKsBySubjects(subjects []types.Subject) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPKsBySubjects", subjects)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPKsBySubjects indicates an expected call of ListPKsBySubjects
-func (mr *MockSubjectServiceMockRecorder) ListPKsBySubjects(subjects interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPKsBySubjects", reflect.TypeOf((*MockSubjectService)(nil).ListPKsBySubjects), subjects)
-}
-
-// ListByPKs mocks base method
-func (m *MockSubjectService) ListByPKs(pks []int64) ([]types.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByPKs", pks)
-	ret0, _ := ret[0].([]types.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByPKs indicates an expected call of ListByPKs
-func (mr *MockSubjectServiceMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockSubjectService)(nil).ListByPKs), pks)
-}
-
-// BulkCreate mocks base method
+// BulkCreate mocks base method.
 func (m *MockSubjectService) BulkCreate(subjects []types.Subject) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkCreate", subjects)
@@ -131,13 +42,55 @@ func (m *MockSubjectService) BulkCreate(subjects []types.Subject) error {
 	return ret0
 }
 
-// BulkCreate indicates an expected call of BulkCreate
+// BulkCreate indicates an expected call of BulkCreate.
 func (mr *MockSubjectServiceMockRecorder) BulkCreate(subjects interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreate", reflect.TypeOf((*MockSubjectService)(nil).BulkCreate), subjects)
 }
 
-// BulkDelete mocks base method
+// BulkCreateSubjectDepartments mocks base method.
+func (m *MockSubjectService) BulkCreateSubjectDepartments(subjectDepartments []types.SubjectDepartment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateSubjectDepartments", subjectDepartments)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateSubjectDepartments indicates an expected call of BulkCreateSubjectDepartments.
+func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectDepartments(subjectDepartments interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectDepartments", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectDepartments), subjectDepartments)
+}
+
+// BulkCreateSubjectMembers mocks base method.
+func (m *MockSubjectService) BulkCreateSubjectMembers(_type, id string, members []types.Subject, policyExpiredAt int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateSubjectMembers", _type, id, members, policyExpiredAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateSubjectMembers indicates an expected call of BulkCreateSubjectMembers.
+func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectMembers(_type, id, members, policyExpiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectMembers", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectMembers), _type, id, members, policyExpiredAt)
+}
+
+// BulkCreateSubjectRoles mocks base method.
+func (m *MockSubjectService) BulkCreateSubjectRoles(roleType, system string, subjects []types.Subject) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkCreateSubjectRoles", roleType, system, subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkCreateSubjectRoles indicates an expected call of BulkCreateSubjectRoles.
+func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectRoles(roleType, system, subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectRoles", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectRoles), roleType, system, subjects)
+}
+
+// BulkDelete mocks base method.
 func (m *MockSubjectService) BulkDelete(subjects []types.Subject) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDelete", subjects)
@@ -146,279 +99,13 @@ func (m *MockSubjectService) BulkDelete(subjects []types.Subject) ([]int64, erro
 	return ret0, ret1
 }
 
-// BulkDelete indicates an expected call of BulkDelete
+// BulkDelete indicates an expected call of BulkDelete.
 func (mr *MockSubjectServiceMockRecorder) BulkDelete(subjects interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDelete", reflect.TypeOf((*MockSubjectService)(nil).BulkDelete), subjects)
 }
 
-// BulkUpdateName mocks base method
-func (m *MockSubjectService) BulkUpdateName(subjects []types.Subject) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdateName", subjects)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkUpdateName indicates an expected call of BulkUpdateName
-func (mr *MockSubjectServiceMockRecorder) BulkUpdateName(subjects interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateName", reflect.TypeOf((*MockSubjectService)(nil).BulkUpdateName), subjects)
-}
-
-// GetEffectThinSubjectGroups mocks base method
-func (m *MockSubjectService) GetEffectThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEffectThinSubjectGroups", pk)
-	ret0, _ := ret[0].([]types.ThinSubjectGroup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEffectThinSubjectGroups indicates an expected call of GetEffectThinSubjectGroups
-func (mr *MockSubjectServiceMockRecorder) GetEffectThinSubjectGroups(pk interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).GetEffectThinSubjectGroups), pk)
-}
-
-// ListEffectThinSubjectGroups mocks base method
-func (m *MockSubjectService) ListEffectThinSubjectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEffectThinSubjectGroups", pks)
-	ret0, _ := ret[0].(map[int64][]types.ThinSubjectGroup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEffectThinSubjectGroups indicates an expected call of ListEffectThinSubjectGroups
-func (mr *MockSubjectServiceMockRecorder) ListEffectThinSubjectGroups(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListEffectThinSubjectGroups), pks)
-}
-
-// ListSubjectGroups mocks base method
-func (m *MockSubjectService) ListSubjectGroups(_type, id string, beforeExpiredAt int64) ([]types.SubjectGroup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSubjectGroups", _type, id, beforeExpiredAt)
-	ret0, _ := ret[0].([]types.SubjectGroup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSubjectGroups indicates an expected call of ListSubjectGroups
-func (mr *MockSubjectServiceMockRecorder) ListSubjectGroups(_type, id, beforeExpiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListSubjectGroups), _type, id, beforeExpiredAt)
-}
-
-// GetMemberCount mocks base method
-func (m *MockSubjectService) GetMemberCount(_type, id string) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCount", _type, id)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemberCount indicates an expected call of GetMemberCount
-func (mr *MockSubjectServiceMockRecorder) GetMemberCount(_type, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockSubjectService)(nil).GetMemberCount), _type, id)
-}
-
-// GetMemberCountBeforeExpiredAt mocks base method
-func (m *MockSubjectService) GetMemberCountBeforeExpiredAt(_type, id string, expiredAt int64) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCountBeforeExpiredAt", _type, id, expiredAt)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemberCountBeforeExpiredAt indicates an expected call of GetMemberCountBeforeExpiredAt
-func (mr *MockSubjectServiceMockRecorder) GetMemberCountBeforeExpiredAt(_type, id, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).GetMemberCountBeforeExpiredAt), _type, id, expiredAt)
-}
-
-// ListPagingMember mocks base method
-func (m *MockSubjectService) ListPagingMember(_type, id string, limit, offset int64) ([]types.SubjectMember, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingMember", _type, id, limit, offset)
-	ret0, _ := ret[0].([]types.SubjectMember)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPagingMember indicates an expected call of ListPagingMember
-func (mr *MockSubjectServiceMockRecorder) ListPagingMember(_type, id, limit, offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMember", reflect.TypeOf((*MockSubjectService)(nil).ListPagingMember), _type, id, limit, offset)
-}
-
-// ListPagingMemberBeforeExpiredAt mocks base method
-func (m *MockSubjectService) ListPagingMemberBeforeExpiredAt(_type, id string, expiredAt, limit, offset int64) ([]types.SubjectMember, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingMemberBeforeExpiredAt", _type, id, expiredAt, limit, offset)
-	ret0, _ := ret[0].([]types.SubjectMember)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPagingMemberBeforeExpiredAt indicates an expected call of ListPagingMemberBeforeExpiredAt
-func (mr *MockSubjectServiceMockRecorder) ListPagingMemberBeforeExpiredAt(_type, id, expiredAt, limit, offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMemberBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).ListPagingMemberBeforeExpiredAt), _type, id, expiredAt, limit, offset)
-}
-
-// ListExistSubjectsBeforeExpiredAt mocks base method
-func (m *MockSubjectService) ListExistSubjectsBeforeExpiredAt(subjects []types.Subject, expiredAt int64) ([]types.Subject, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExistSubjectsBeforeExpiredAt", subjects, expiredAt)
-	ret0, _ := ret[0].([]types.Subject)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListExistSubjectsBeforeExpiredAt indicates an expected call of ListExistSubjectsBeforeExpiredAt
-func (mr *MockSubjectServiceMockRecorder) ListExistSubjectsBeforeExpiredAt(subjects, expiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExistSubjectsBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).ListExistSubjectsBeforeExpiredAt), subjects, expiredAt)
-}
-
-// ListMember mocks base method
-func (m *MockSubjectService) ListMember(_type, id string) ([]types.SubjectMember, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMember", _type, id)
-	ret0, _ := ret[0].([]types.SubjectMember)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListMember indicates an expected call of ListMember
-func (mr *MockSubjectServiceMockRecorder) ListMember(_type, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMember", reflect.TypeOf((*MockSubjectService)(nil).ListMember), _type, id)
-}
-
-// UpdateMembersExpiredAt mocks base method
-func (m *MockSubjectService) UpdateMembersExpiredAt(members []types.SubjectMember) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMembersExpiredAt", members)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateMembersExpiredAt indicates an expected call of UpdateMembersExpiredAt
-func (mr *MockSubjectServiceMockRecorder) UpdateMembersExpiredAt(members interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMembersExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).UpdateMembersExpiredAt), members)
-}
-
-// BulkDeleteSubjectMembers mocks base method
-func (m *MockSubjectService) BulkDeleteSubjectMembers(_type, id string, members []types.Subject) (map[string]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteSubjectMembers", _type, id, members)
-	ret0, _ := ret[0].(map[string]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BulkDeleteSubjectMembers indicates an expected call of BulkDeleteSubjectMembers
-func (mr *MockSubjectServiceMockRecorder) BulkDeleteSubjectMembers(_type, id, members interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteSubjectMembers", reflect.TypeOf((*MockSubjectService)(nil).BulkDeleteSubjectMembers), _type, id, members)
-}
-
-// BulkCreateSubjectMembers mocks base method
-func (m *MockSubjectService) BulkCreateSubjectMembers(_type, id string, members []types.Subject, policyExpiredAt int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateSubjectMembers", _type, id, members, policyExpiredAt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreateSubjectMembers indicates an expected call of BulkCreateSubjectMembers
-func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectMembers(_type, id, members, policyExpiredAt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectMembers", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectMembers), _type, id, members, policyExpiredAt)
-}
-
-// GetSubjectDepartmentPKs mocks base method
-func (m *MockSubjectService) GetSubjectDepartmentPKs(subjectPK int64) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubjectDepartmentPKs", subjectPK)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubjectDepartmentPKs indicates an expected call of GetSubjectDepartmentPKs
-func (mr *MockSubjectServiceMockRecorder) GetSubjectDepartmentPKs(subjectPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubjectDepartmentPKs", reflect.TypeOf((*MockSubjectService)(nil).GetSubjectDepartmentPKs), subjectPK)
-}
-
-// GetSubjectDepartmentCount mocks base method
-func (m *MockSubjectService) GetSubjectDepartmentCount() (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubjectDepartmentCount")
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubjectDepartmentCount indicates an expected call of GetSubjectDepartmentCount
-func (mr *MockSubjectServiceMockRecorder) GetSubjectDepartmentCount() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubjectDepartmentCount", reflect.TypeOf((*MockSubjectService)(nil).GetSubjectDepartmentCount))
-}
-
-// ListPagingSubjectDepartment mocks base method
-func (m *MockSubjectService) ListPagingSubjectDepartment(limit, offset int64) ([]types.SubjectDepartment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPagingSubjectDepartment", limit, offset)
-	ret0, _ := ret[0].([]types.SubjectDepartment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPagingSubjectDepartment indicates an expected call of ListPagingSubjectDepartment
-func (mr *MockSubjectServiceMockRecorder) ListPagingSubjectDepartment(limit, offset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingSubjectDepartment", reflect.TypeOf((*MockSubjectService)(nil).ListPagingSubjectDepartment), limit, offset)
-}
-
-// BulkCreateSubjectDepartments mocks base method
-func (m *MockSubjectService) BulkCreateSubjectDepartments(subjectDepartments []types.SubjectDepartment) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateSubjectDepartments", subjectDepartments)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkCreateSubjectDepartments indicates an expected call of BulkCreateSubjectDepartments
-func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectDepartments(subjectDepartments interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectDepartments", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectDepartments), subjectDepartments)
-}
-
-// BulkUpdateSubjectDepartments mocks base method
-func (m *MockSubjectService) BulkUpdateSubjectDepartments(subjectDepartments []types.SubjectDepartment) ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkUpdateSubjectDepartments", subjectDepartments)
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BulkUpdateSubjectDepartments indicates an expected call of BulkUpdateSubjectDepartments
-func (mr *MockSubjectServiceMockRecorder) BulkUpdateSubjectDepartments(subjectDepartments interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateSubjectDepartments", reflect.TypeOf((*MockSubjectService)(nil).BulkUpdateSubjectDepartments), subjectDepartments)
-}
-
-// BulkDeleteSubjectDepartments mocks base method
+// BulkDeleteSubjectDepartments mocks base method.
 func (m *MockSubjectService) BulkDeleteSubjectDepartments(subjectIDs []string) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkDeleteSubjectDepartments", subjectIDs)
@@ -427,28 +114,326 @@ func (m *MockSubjectService) BulkDeleteSubjectDepartments(subjectIDs []string) (
 	return ret0, ret1
 }
 
-// BulkDeleteSubjectDepartments indicates an expected call of BulkDeleteSubjectDepartments
+// BulkDeleteSubjectDepartments indicates an expected call of BulkDeleteSubjectDepartments.
 func (mr *MockSubjectServiceMockRecorder) BulkDeleteSubjectDepartments(subjectIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteSubjectDepartments", reflect.TypeOf((*MockSubjectService)(nil).BulkDeleteSubjectDepartments), subjectIDs)
 }
 
-// ListSubjectPKByRole mocks base method
-func (m *MockSubjectService) ListSubjectPKByRole(roleType, system string) ([]int64, error) {
+// BulkDeleteSubjectMembers mocks base method.
+func (m *MockSubjectService) BulkDeleteSubjectMembers(_type, id string, members []types.Subject) (map[string]int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSubjectPKByRole", roleType, system)
+	ret := m.ctrl.Call(m, "BulkDeleteSubjectMembers", _type, id, members)
+	ret0, _ := ret[0].(map[string]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BulkDeleteSubjectMembers indicates an expected call of BulkDeleteSubjectMembers.
+func (mr *MockSubjectServiceMockRecorder) BulkDeleteSubjectMembers(_type, id, members interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteSubjectMembers", reflect.TypeOf((*MockSubjectService)(nil).BulkDeleteSubjectMembers), _type, id, members)
+}
+
+// BulkDeleteSubjectRoles mocks base method.
+func (m *MockSubjectService) BulkDeleteSubjectRoles(roleType, system string, subjects []types.Subject) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkDeleteSubjectRoles", roleType, system, subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkDeleteSubjectRoles indicates an expected call of BulkDeleteSubjectRoles.
+func (mr *MockSubjectServiceMockRecorder) BulkDeleteSubjectRoles(roleType, system, subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteSubjectRoles", reflect.TypeOf((*MockSubjectService)(nil).BulkDeleteSubjectRoles), roleType, system, subjects)
+}
+
+// BulkUpdateName mocks base method.
+func (m *MockSubjectService) BulkUpdateName(subjects []types.Subject) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdateName", subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkUpdateName indicates an expected call of BulkUpdateName.
+func (mr *MockSubjectServiceMockRecorder) BulkUpdateName(subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateName", reflect.TypeOf((*MockSubjectService)(nil).BulkUpdateName), subjects)
+}
+
+// BulkUpdateSubjectDepartments mocks base method.
+func (m *MockSubjectService) BulkUpdateSubjectDepartments(subjectDepartments []types.SubjectDepartment) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdateSubjectDepartments", subjectDepartments)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListSubjectPKByRole indicates an expected call of ListSubjectPKByRole
-func (mr *MockSubjectServiceMockRecorder) ListSubjectPKByRole(roleType, system interface{}) *gomock.Call {
+// BulkUpdateSubjectDepartments indicates an expected call of BulkUpdateSubjectDepartments.
+func (mr *MockSubjectServiceMockRecorder) BulkUpdateSubjectDepartments(subjectDepartments interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectPKByRole", reflect.TypeOf((*MockSubjectService)(nil).ListSubjectPKByRole), roleType, system)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateSubjectDepartments", reflect.TypeOf((*MockSubjectService)(nil).BulkUpdateSubjectDepartments), subjectDepartments)
 }
 
-// ListRoleSystemIDBySubjectPK mocks base method
+// Get mocks base method.
+func (m *MockSubjectService) Get(pk int64) (types.Subject, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", pk)
+	ret0, _ := ret[0].(types.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockSubjectServiceMockRecorder) Get(pk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSubjectService)(nil).Get), pk)
+}
+
+// GetCount mocks base method.
+func (m *MockSubjectService) GetCount(_type string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCount", _type)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCount indicates an expected call of GetCount.
+func (mr *MockSubjectServiceMockRecorder) GetCount(_type interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCount", reflect.TypeOf((*MockSubjectService)(nil).GetCount), _type)
+}
+
+// GetEffectThinSubjectGroups mocks base method.
+func (m *MockSubjectService) GetEffectThinSubjectGroups(pk int64) ([]types.ThinSubjectGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEffectThinSubjectGroups", pk)
+	ret0, _ := ret[0].([]types.ThinSubjectGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEffectThinSubjectGroups indicates an expected call of GetEffectThinSubjectGroups.
+func (mr *MockSubjectServiceMockRecorder) GetEffectThinSubjectGroups(pk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).GetEffectThinSubjectGroups), pk)
+}
+
+// GetMemberCount mocks base method.
+func (m *MockSubjectService) GetMemberCount(_type, id string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemberCount", _type, id)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMemberCount indicates an expected call of GetMemberCount.
+func (mr *MockSubjectServiceMockRecorder) GetMemberCount(_type, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockSubjectService)(nil).GetMemberCount), _type, id)
+}
+
+// GetMemberCountBeforeExpiredAt mocks base method.
+func (m *MockSubjectService) GetMemberCountBeforeExpiredAt(_type, id string, expiredAt int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemberCountBeforeExpiredAt", _type, id, expiredAt)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMemberCountBeforeExpiredAt indicates an expected call of GetMemberCountBeforeExpiredAt.
+func (mr *MockSubjectServiceMockRecorder) GetMemberCountBeforeExpiredAt(_type, id, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).GetMemberCountBeforeExpiredAt), _type, id, expiredAt)
+}
+
+// GetPK mocks base method.
+func (m *MockSubjectService) GetPK(_type, id string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPK", _type, id)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPK indicates an expected call of GetPK.
+func (mr *MockSubjectServiceMockRecorder) GetPK(_type, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPK", reflect.TypeOf((*MockSubjectService)(nil).GetPK), _type, id)
+}
+
+// GetSubjectDepartmentCount mocks base method.
+func (m *MockSubjectService) GetSubjectDepartmentCount() (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubjectDepartmentCount")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubjectDepartmentCount indicates an expected call of GetSubjectDepartmentCount.
+func (mr *MockSubjectServiceMockRecorder) GetSubjectDepartmentCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubjectDepartmentCount", reflect.TypeOf((*MockSubjectService)(nil).GetSubjectDepartmentCount))
+}
+
+// GetSubjectDepartmentPKs mocks base method.
+func (m *MockSubjectService) GetSubjectDepartmentPKs(subjectPK int64) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubjectDepartmentPKs", subjectPK)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubjectDepartmentPKs indicates an expected call of GetSubjectDepartmentPKs.
+func (mr *MockSubjectServiceMockRecorder) GetSubjectDepartmentPKs(subjectPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubjectDepartmentPKs", reflect.TypeOf((*MockSubjectService)(nil).GetSubjectDepartmentPKs), subjectPK)
+}
+
+// ListByPKs mocks base method.
+func (m *MockSubjectService) ListByPKs(pks []int64) ([]types.Subject, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByPKs", pks)
+	ret0, _ := ret[0].([]types.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByPKs indicates an expected call of ListByPKs.
+func (mr *MockSubjectServiceMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockSubjectService)(nil).ListByPKs), pks)
+}
+
+// ListEffectThinSubjectGroups mocks base method.
+func (m *MockSubjectService) ListEffectThinSubjectGroups(pks []int64) (map[int64][]types.ThinSubjectGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEffectThinSubjectGroups", pks)
+	ret0, _ := ret[0].(map[int64][]types.ThinSubjectGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEffectThinSubjectGroups indicates an expected call of ListEffectThinSubjectGroups.
+func (mr *MockSubjectServiceMockRecorder) ListEffectThinSubjectGroups(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEffectThinSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListEffectThinSubjectGroups), pks)
+}
+
+// ListExistSubjectsBeforeExpiredAt mocks base method.
+func (m *MockSubjectService) ListExistSubjectsBeforeExpiredAt(subjects []types.Subject, expiredAt int64) ([]types.Subject, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExistSubjectsBeforeExpiredAt", subjects, expiredAt)
+	ret0, _ := ret[0].([]types.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExistSubjectsBeforeExpiredAt indicates an expected call of ListExistSubjectsBeforeExpiredAt.
+func (mr *MockSubjectServiceMockRecorder) ListExistSubjectsBeforeExpiredAt(subjects, expiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExistSubjectsBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).ListExistSubjectsBeforeExpiredAt), subjects, expiredAt)
+}
+
+// ListMember mocks base method.
+func (m *MockSubjectService) ListMember(_type, id string) ([]types.SubjectMember, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMember", _type, id)
+	ret0, _ := ret[0].([]types.SubjectMember)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMember indicates an expected call of ListMember.
+func (mr *MockSubjectServiceMockRecorder) ListMember(_type, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMember", reflect.TypeOf((*MockSubjectService)(nil).ListMember), _type, id)
+}
+
+// ListPKsBySubjects mocks base method.
+func (m *MockSubjectService) ListPKsBySubjects(subjects []types.Subject) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPKsBySubjects", subjects)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPKsBySubjects indicates an expected call of ListPKsBySubjects.
+func (mr *MockSubjectServiceMockRecorder) ListPKsBySubjects(subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPKsBySubjects", reflect.TypeOf((*MockSubjectService)(nil).ListPKsBySubjects), subjects)
+}
+
+// ListPaging mocks base method.
+func (m *MockSubjectService) ListPaging(_type string, limit, offset int64) ([]types.Subject, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPaging", _type, limit, offset)
+	ret0, _ := ret[0].([]types.Subject)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPaging indicates an expected call of ListPaging.
+func (mr *MockSubjectServiceMockRecorder) ListPaging(_type, limit, offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaging", reflect.TypeOf((*MockSubjectService)(nil).ListPaging), _type, limit, offset)
+}
+
+// ListPagingMember mocks base method.
+func (m *MockSubjectService) ListPagingMember(_type, id string, limit, offset int64) ([]types.SubjectMember, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPagingMember", _type, id, limit, offset)
+	ret0, _ := ret[0].([]types.SubjectMember)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPagingMember indicates an expected call of ListPagingMember.
+func (mr *MockSubjectServiceMockRecorder) ListPagingMember(_type, id, limit, offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMember", reflect.TypeOf((*MockSubjectService)(nil).ListPagingMember), _type, id, limit, offset)
+}
+
+// ListPagingMemberBeforeExpiredAt mocks base method.
+func (m *MockSubjectService) ListPagingMemberBeforeExpiredAt(_type, id string, expiredAt, limit, offset int64) ([]types.SubjectMember, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPagingMemberBeforeExpiredAt", _type, id, expiredAt, limit, offset)
+	ret0, _ := ret[0].([]types.SubjectMember)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPagingMemberBeforeExpiredAt indicates an expected call of ListPagingMemberBeforeExpiredAt.
+func (mr *MockSubjectServiceMockRecorder) ListPagingMemberBeforeExpiredAt(_type, id, expiredAt, limit, offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingMemberBeforeExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).ListPagingMemberBeforeExpiredAt), _type, id, expiredAt, limit, offset)
+}
+
+// ListPagingSubjectDepartment mocks base method.
+func (m *MockSubjectService) ListPagingSubjectDepartment(limit, offset int64) ([]types.SubjectDepartment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPagingSubjectDepartment", limit, offset)
+	ret0, _ := ret[0].([]types.SubjectDepartment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPagingSubjectDepartment indicates an expected call of ListPagingSubjectDepartment.
+func (mr *MockSubjectServiceMockRecorder) ListPagingSubjectDepartment(limit, offset interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPagingSubjectDepartment", reflect.TypeOf((*MockSubjectService)(nil).ListPagingSubjectDepartment), limit, offset)
+}
+
+// ListRoleSystemIDBySubjectPK mocks base method.
 func (m *MockSubjectService) ListRoleSystemIDBySubjectPK(pk int64) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRoleSystemIDBySubjectPK", pk)
@@ -457,36 +442,52 @@ func (m *MockSubjectService) ListRoleSystemIDBySubjectPK(pk int64) ([]string, er
 	return ret0, ret1
 }
 
-// ListRoleSystemIDBySubjectPK indicates an expected call of ListRoleSystemIDBySubjectPK
+// ListRoleSystemIDBySubjectPK indicates an expected call of ListRoleSystemIDBySubjectPK.
 func (mr *MockSubjectServiceMockRecorder) ListRoleSystemIDBySubjectPK(pk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleSystemIDBySubjectPK", reflect.TypeOf((*MockSubjectService)(nil).ListRoleSystemIDBySubjectPK), pk)
 }
 
-// BulkCreateSubjectRoles mocks base method
-func (m *MockSubjectService) BulkCreateSubjectRoles(roleType, system string, subjects []types.Subject) error {
+// ListSubjectGroups mocks base method.
+func (m *MockSubjectService) ListSubjectGroups(_type, id string, beforeExpiredAt int64) ([]types.SubjectGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkCreateSubjectRoles", roleType, system, subjects)
+	ret := m.ctrl.Call(m, "ListSubjectGroups", _type, id, beforeExpiredAt)
+	ret0, _ := ret[0].([]types.SubjectGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSubjectGroups indicates an expected call of ListSubjectGroups.
+func (mr *MockSubjectServiceMockRecorder) ListSubjectGroups(_type, id, beforeExpiredAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectGroups", reflect.TypeOf((*MockSubjectService)(nil).ListSubjectGroups), _type, id, beforeExpiredAt)
+}
+
+// ListSubjectPKByRole mocks base method.
+func (m *MockSubjectService) ListSubjectPKByRole(roleType, system string) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSubjectPKByRole", roleType, system)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSubjectPKByRole indicates an expected call of ListSubjectPKByRole.
+func (mr *MockSubjectServiceMockRecorder) ListSubjectPKByRole(roleType, system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjectPKByRole", reflect.TypeOf((*MockSubjectService)(nil).ListSubjectPKByRole), roleType, system)
+}
+
+// UpdateMembersExpiredAt mocks base method.
+func (m *MockSubjectService) UpdateMembersExpiredAt(members []types.SubjectMember) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMembersExpiredAt", members)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// BulkCreateSubjectRoles indicates an expected call of BulkCreateSubjectRoles
-func (mr *MockSubjectServiceMockRecorder) BulkCreateSubjectRoles(roleType, system, subjects interface{}) *gomock.Call {
+// UpdateMembersExpiredAt indicates an expected call of UpdateMembersExpiredAt.
+func (mr *MockSubjectServiceMockRecorder) UpdateMembersExpiredAt(members interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubjectRoles", reflect.TypeOf((*MockSubjectService)(nil).BulkCreateSubjectRoles), roleType, system, subjects)
-}
-
-// BulkDeleteSubjectRoles mocks base method
-func (m *MockSubjectService) BulkDeleteSubjectRoles(roleType, system string, subjects []types.Subject) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BulkDeleteSubjectRoles", roleType, system, subjects)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BulkDeleteSubjectRoles indicates an expected call of BulkDeleteSubjectRoles
-func (mr *MockSubjectServiceMockRecorder) BulkDeleteSubjectRoles(roleType, system, subjects interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkDeleteSubjectRoles", reflect.TypeOf((*MockSubjectService)(nil).BulkDeleteSubjectRoles), roleType, system, subjects)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMembersExpiredAt", reflect.TypeOf((*MockSubjectService)(nil).UpdateMembersExpiredAt), members)
 }

--- a/pkg/service/mock/system.go
+++ b/pkg/service/mock/system.go
@@ -5,35 +5,64 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSystemService is a mock of SystemService interface
+// MockSystemService is a mock of SystemService interface.
 type MockSystemService struct {
 	ctrl     *gomock.Controller
 	recorder *MockSystemServiceMockRecorder
 }
 
-// MockSystemServiceMockRecorder is the mock recorder for MockSystemService
+// MockSystemServiceMockRecorder is the mock recorder for MockSystemService.
 type MockSystemServiceMockRecorder struct {
 	mock *MockSystemService
 }
 
-// NewMockSystemService creates a new mock instance
+// NewMockSystemService creates a new mock instance.
 func NewMockSystemService(ctrl *gomock.Controller) *MockSystemService {
 	mock := &MockSystemService{ctrl: ctrl}
 	mock.recorder = &MockSystemServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSystemService) EXPECT() *MockSystemServiceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Create mocks base method.
+func (m *MockSystemService) Create(system types.System) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", system)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockSystemServiceMockRecorder) Create(system interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSystemService)(nil).Create), system)
+}
+
+// Exists mocks base method.
+func (m *MockSystemService) Exists(id string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", id)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockSystemServiceMockRecorder) Exists(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSystemService)(nil).Exists), id)
+}
+
+// Get mocks base method.
 func (m *MockSystemService) Get(id string) (types.System, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", id)
@@ -42,27 +71,13 @@ func (m *MockSystemService) Get(id string) (types.System, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSystemServiceMockRecorder) Get(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSystemService)(nil).Get), id)
 }
 
-// Exists mocks base method
-func (m *MockSystemService) Exists(id string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", id)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// Exists indicates an expected call of Exists
-func (mr *MockSystemServiceMockRecorder) Exists(id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSystemService)(nil).Exists), id)
-}
-
-// ListAll mocks base method
+// ListAll mocks base method.
 func (m *MockSystemService) ListAll() ([]types.System, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAll")
@@ -71,27 +86,13 @@ func (m *MockSystemService) ListAll() ([]types.System, error) {
 	return ret0, ret1
 }
 
-// ListAll indicates an expected call of ListAll
+// ListAll indicates an expected call of ListAll.
 func (mr *MockSystemServiceMockRecorder) ListAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockSystemService)(nil).ListAll))
 }
 
-// Create mocks base method
-func (m *MockSystemService) Create(system types.System) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", system)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Create indicates an expected call of Create
-func (mr *MockSystemServiceMockRecorder) Create(system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSystemService)(nil).Create), system)
-}
-
-// Update mocks base method
+// Update mocks base method.
 func (m *MockSystemService) Update(id string, system types.System) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", id, system)
@@ -99,7 +100,7 @@ func (m *MockSystemService) Update(id string, system types.System) error {
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockSystemServiceMockRecorder) Update(id, system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSystemService)(nil).Update), id, system)

--- a/pkg/service/mock/system_config.go
+++ b/pkg/service/mock/system_config.go
@@ -5,49 +5,91 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSystemConfigService is a mock of SystemConfigService interface
+// MockSystemConfigService is a mock of SystemConfigService interface.
 type MockSystemConfigService struct {
 	ctrl     *gomock.Controller
 	recorder *MockSystemConfigServiceMockRecorder
 }
 
-// MockSystemConfigServiceMockRecorder is the mock recorder for MockSystemConfigService
+// MockSystemConfigServiceMockRecorder is the mock recorder for MockSystemConfigService.
 type MockSystemConfigServiceMockRecorder struct {
 	mock *MockSystemConfigService
 }
 
-// NewMockSystemConfigService creates a new mock instance
+// NewMockSystemConfigService creates a new mock instance.
 func NewMockSystemConfigService(ctrl *gomock.Controller) *MockSystemConfigService {
 	mock := &MockSystemConfigService{ctrl: ctrl}
 	mock.recorder = &MockSystemConfigServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSystemConfigService) EXPECT() *MockSystemConfigServiceMockRecorder {
 	return m.recorder
 }
 
-// get mocks base method
-func (m *MockSystemConfigService) get(system, key string) (interface{}, error) {
+// CreateOrUpdateActionGroups mocks base method.
+func (m *MockSystemConfigService) CreateOrUpdateActionGroups(system string, actionGroup []interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "get", system, key)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "CreateOrUpdateActionGroups", system, actionGroup)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// get indicates an expected call of get
-func (mr *MockSystemConfigServiceMockRecorder) get(system, key interface{}) *gomock.Call {
+// CreateOrUpdateActionGroups indicates an expected call of CreateOrUpdateActionGroups.
+func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateActionGroups(system, actionGroup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "get", reflect.TypeOf((*MockSystemConfigService)(nil).get), system, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateActionGroups", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateActionGroups), system, actionGroup)
 }
 
-// Exists mocks base method
+// CreateOrUpdateCommonActions mocks base method.
+func (m *MockSystemConfigService) CreateOrUpdateCommonActions(system string, actions []interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateCommonActions", system, actions)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateCommonActions indicates an expected call of CreateOrUpdateCommonActions.
+func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateCommonActions(system, actions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateCommonActions", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateCommonActions), system, actions)
+}
+
+// CreateOrUpdateFeatureShieldRules mocks base method.
+func (m *MockSystemConfigService) CreateOrUpdateFeatureShieldRules(system string, featureShieldRules []interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateFeatureShieldRules", system, featureShieldRules)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateFeatureShieldRules indicates an expected call of CreateOrUpdateFeatureShieldRules.
+func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateFeatureShieldRules(system, featureShieldRules interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateFeatureShieldRules", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateFeatureShieldRules), system, featureShieldRules)
+}
+
+// CreateOrUpdateResourceCreatorActions mocks base method.
+func (m *MockSystemConfigService) CreateOrUpdateResourceCreatorActions(system string, resourceCreatorAction map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateResourceCreatorActions", system, resourceCreatorAction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateResourceCreatorActions indicates an expected call of CreateOrUpdateResourceCreatorActions.
+func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateResourceCreatorActions(system, resourceCreatorAction interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateResourceCreatorActions", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateResourceCreatorActions), system, resourceCreatorAction)
+}
+
+// Exists mocks base method.
 func (m *MockSystemConfigService) Exists(system, key string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", system, key)
@@ -55,13 +97,13 @@ func (m *MockSystemConfigService) Exists(system, key string) bool {
 	return ret0
 }
 
-// Exists indicates an expected call of Exists
+// Exists indicates an expected call of Exists.
 func (mr *MockSystemConfigServiceMockRecorder) Exists(system, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSystemConfigService)(nil).Exists), system, key)
 }
 
-// GetActionGroups mocks base method
+// GetActionGroups mocks base method.
 func (m *MockSystemConfigService) GetActionGroups(system string) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionGroups", system)
@@ -70,56 +112,13 @@ func (m *MockSystemConfigService) GetActionGroups(system string) ([]interface{},
 	return ret0, ret1
 }
 
-// GetActionGroups indicates an expected call of GetActionGroups
+// GetActionGroups indicates an expected call of GetActionGroups.
 func (mr *MockSystemConfigServiceMockRecorder) GetActionGroups(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionGroups", reflect.TypeOf((*MockSystemConfigService)(nil).GetActionGroups), system)
 }
 
-// CreateOrUpdateActionGroups mocks base method
-func (m *MockSystemConfigService) CreateOrUpdateActionGroups(system string, actionGroup []interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateActionGroups", system, actionGroup)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOrUpdateActionGroups indicates an expected call of CreateOrUpdateActionGroups
-func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateActionGroups(system, actionGroup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateActionGroups", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateActionGroups), system, actionGroup)
-}
-
-// GetResourceCreatorActions mocks base method
-func (m *MockSystemConfigService) GetResourceCreatorActions(system string) (map[string]interface{}, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourceCreatorActions", system)
-	ret0, _ := ret[0].(map[string]interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResourceCreatorActions indicates an expected call of GetResourceCreatorActions
-func (mr *MockSystemConfigServiceMockRecorder) GetResourceCreatorActions(system interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceCreatorActions", reflect.TypeOf((*MockSystemConfigService)(nil).GetResourceCreatorActions), system)
-}
-
-// CreateOrUpdateResourceCreatorActions mocks base method
-func (m *MockSystemConfigService) CreateOrUpdateResourceCreatorActions(system string, resourceCreatorAction map[string]interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateResourceCreatorActions", system, resourceCreatorAction)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOrUpdateResourceCreatorActions indicates an expected call of CreateOrUpdateResourceCreatorActions
-func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateResourceCreatorActions(system, resourceCreatorAction interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateResourceCreatorActions", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateResourceCreatorActions), system, resourceCreatorAction)
-}
-
-// GetCommonActions mocks base method
+// GetCommonActions mocks base method.
 func (m *MockSystemConfigService) GetCommonActions(system string) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommonActions", system)
@@ -128,27 +127,13 @@ func (m *MockSystemConfigService) GetCommonActions(system string) ([]interface{}
 	return ret0, ret1
 }
 
-// GetCommonActions indicates an expected call of GetCommonActions
+// GetCommonActions indicates an expected call of GetCommonActions.
 func (mr *MockSystemConfigServiceMockRecorder) GetCommonActions(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommonActions", reflect.TypeOf((*MockSystemConfigService)(nil).GetCommonActions), system)
 }
 
-// CreateOrUpdateCommonActions mocks base method
-func (m *MockSystemConfigService) CreateOrUpdateCommonActions(system string, actions []interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateCommonActions", system, actions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOrUpdateCommonActions indicates an expected call of CreateOrUpdateCommonActions
-func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateCommonActions(system, actions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateCommonActions", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateCommonActions), system, actions)
-}
-
-// GetFeatureShieldRules mocks base method
+// GetFeatureShieldRules mocks base method.
 func (m *MockSystemConfigService) GetFeatureShieldRules(system string) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFeatureShieldRules", system)
@@ -157,22 +142,38 @@ func (m *MockSystemConfigService) GetFeatureShieldRules(system string) ([]interf
 	return ret0, ret1
 }
 
-// GetFeatureShieldRules indicates an expected call of GetFeatureShieldRules
+// GetFeatureShieldRules indicates an expected call of GetFeatureShieldRules.
 func (mr *MockSystemConfigServiceMockRecorder) GetFeatureShieldRules(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeatureShieldRules", reflect.TypeOf((*MockSystemConfigService)(nil).GetFeatureShieldRules), system)
 }
 
-// CreateOrUpdateFeatureShieldRules mocks base method
-func (m *MockSystemConfigService) CreateOrUpdateFeatureShieldRules(system string, featureShieldRules []interface{}) error {
+// GetResourceCreatorActions mocks base method.
+func (m *MockSystemConfigService) GetResourceCreatorActions(system string) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateFeatureShieldRules", system, featureShieldRules)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetResourceCreatorActions", system)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// CreateOrUpdateFeatureShieldRules indicates an expected call of CreateOrUpdateFeatureShieldRules
-func (mr *MockSystemConfigServiceMockRecorder) CreateOrUpdateFeatureShieldRules(system, featureShieldRules interface{}) *gomock.Call {
+// GetResourceCreatorActions indicates an expected call of GetResourceCreatorActions.
+func (mr *MockSystemConfigServiceMockRecorder) GetResourceCreatorActions(system interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateFeatureShieldRules", reflect.TypeOf((*MockSystemConfigService)(nil).CreateOrUpdateFeatureShieldRules), system, featureShieldRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceCreatorActions", reflect.TypeOf((*MockSystemConfigService)(nil).GetResourceCreatorActions), system)
+}
+
+// get mocks base method.
+func (m *MockSystemConfigService) get(system, key string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "get", system, key)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// get indicates an expected call of get.
+func (mr *MockSystemConfigServiceMockRecorder) get(system, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "get", reflect.TypeOf((*MockSystemConfigService)(nil).get), system, key)
 }

--- a/pkg/service/mock/temporary_policy.go
+++ b/pkg/service/mock/temporary_policy.go
@@ -5,65 +5,36 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	types "iam/pkg/service/types"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTemporaryPolicyService is a mock of TemporaryPolicyService interface
+// MockTemporaryPolicyService is a mock of TemporaryPolicyService interface.
 type MockTemporaryPolicyService struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemporaryPolicyServiceMockRecorder
 }
 
-// MockTemporaryPolicyServiceMockRecorder is the mock recorder for MockTemporaryPolicyService
+// MockTemporaryPolicyServiceMockRecorder is the mock recorder for MockTemporaryPolicyService.
 type MockTemporaryPolicyServiceMockRecorder struct {
 	mock *MockTemporaryPolicyService
 }
 
-// NewMockTemporaryPolicyService creates a new mock instance
+// NewMockTemporaryPolicyService creates a new mock instance.
 func NewMockTemporaryPolicyService(ctrl *gomock.Controller) *MockTemporaryPolicyService {
 	mock := &MockTemporaryPolicyService{ctrl: ctrl}
 	mock.recorder = &MockTemporaryPolicyServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTemporaryPolicyService) EXPECT() *MockTemporaryPolicyServiceMockRecorder {
 	return m.recorder
 }
 
-// ListThinBySubjectAction mocks base method
-func (m *MockTemporaryPolicyService) ListThinBySubjectAction(subjectPK, actionPK int64) ([]types.ThinTemporaryPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListThinBySubjectAction", subjectPK, actionPK)
-	ret0, _ := ret[0].([]types.ThinTemporaryPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListThinBySubjectAction indicates an expected call of ListThinBySubjectAction
-func (mr *MockTemporaryPolicyServiceMockRecorder) ListThinBySubjectAction(subjectPK, actionPK interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectAction", reflect.TypeOf((*MockTemporaryPolicyService)(nil).ListThinBySubjectAction), subjectPK, actionPK)
-}
-
-// ListByPKs mocks base method
-func (m *MockTemporaryPolicyService) ListByPKs(pks []int64) ([]types.TemporaryPolicy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByPKs", pks)
-	ret0, _ := ret[0].([]types.TemporaryPolicy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByPKs indicates an expected call of ListByPKs
-func (mr *MockTemporaryPolicyServiceMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockTemporaryPolicyService)(nil).ListByPKs), pks)
-}
-
-// Create mocks base method
+// Create mocks base method.
 func (m *MockTemporaryPolicyService) Create(policies []types.TemporaryPolicy) ([]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", policies)
@@ -72,27 +43,13 @@ func (m *MockTemporaryPolicyService) Create(policies []types.TemporaryPolicy) ([
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockTemporaryPolicyServiceMockRecorder) Create(policies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTemporaryPolicyService)(nil).Create), policies)
 }
 
-// DeleteByPKs mocks base method
-func (m *MockTemporaryPolicyService) DeleteByPKs(subjectPK int64, pks []int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByPKs", subjectPK, pks)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByPKs indicates an expected call of DeleteByPKs
-func (mr *MockTemporaryPolicyServiceMockRecorder) DeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPKs", reflect.TypeOf((*MockTemporaryPolicyService)(nil).DeleteByPKs), subjectPK, pks)
-}
-
-// DeleteBeforeExpireAt mocks base method
+// DeleteBeforeExpireAt mocks base method.
 func (m *MockTemporaryPolicyService) DeleteBeforeExpireAt(expiredAt int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBeforeExpireAt", expiredAt)
@@ -100,8 +57,52 @@ func (m *MockTemporaryPolicyService) DeleteBeforeExpireAt(expiredAt int64) error
 	return ret0
 }
 
-// DeleteBeforeExpireAt indicates an expected call of DeleteBeforeExpireAt
+// DeleteBeforeExpireAt indicates an expected call of DeleteBeforeExpireAt.
 func (mr *MockTemporaryPolicyServiceMockRecorder) DeleteBeforeExpireAt(expiredAt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBeforeExpireAt", reflect.TypeOf((*MockTemporaryPolicyService)(nil).DeleteBeforeExpireAt), expiredAt)
+}
+
+// DeleteByPKs mocks base method.
+func (m *MockTemporaryPolicyService) DeleteByPKs(subjectPK int64, pks []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByPKs", subjectPK, pks)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByPKs indicates an expected call of DeleteByPKs.
+func (mr *MockTemporaryPolicyServiceMockRecorder) DeleteByPKs(subjectPK, pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPKs", reflect.TypeOf((*MockTemporaryPolicyService)(nil).DeleteByPKs), subjectPK, pks)
+}
+
+// ListByPKs mocks base method.
+func (m *MockTemporaryPolicyService) ListByPKs(pks []int64) ([]types.TemporaryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByPKs", pks)
+	ret0, _ := ret[0].([]types.TemporaryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByPKs indicates an expected call of ListByPKs.
+func (mr *MockTemporaryPolicyServiceMockRecorder) ListByPKs(pks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByPKs", reflect.TypeOf((*MockTemporaryPolicyService)(nil).ListByPKs), pks)
+}
+
+// ListThinBySubjectAction mocks base method.
+func (m *MockTemporaryPolicyService) ListThinBySubjectAction(subjectPK, actionPK int64) ([]types.ThinTemporaryPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListThinBySubjectAction", subjectPK, actionPK)
+	ret0, _ := ret[0].([]types.ThinTemporaryPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListThinBySubjectAction indicates an expected call of ListThinBySubjectAction.
+func (mr *MockTemporaryPolicyServiceMockRecorder) ListThinBySubjectAction(subjectPK, actionPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThinBySubjectAction", reflect.TypeOf((*MockTemporaryPolicyService)(nil).ListThinBySubjectAction), subjectPK, actionPK)
 }

--- a/pkg/service/subject.go
+++ b/pkg/service/subject.go
@@ -129,12 +129,12 @@ func (l *subjectService) GetPK(_type, id string) (pk int64, err error) {
 
 // GetCount ...
 func (l *subjectService) GetCount(_type string) (int64, error) {
-	cnt, err := l.manager.GetCount(_type)
+	count, err := l.manager.GetCount(_type)
 	if err != nil {
 		err = errorx.Wrapf(err, SubjectSVC, "GetCount", "manager.GetCount _type=`%s` fail", _type)
 		return 0, err
 	}
-	return cnt, nil
+	return count, nil
 }
 
 func convertToSubjects(daoSubjects []dao.Subject) []types.Subject {

--- a/pkg/service/subject_group.go
+++ b/pkg/service/subject_group.go
@@ -165,10 +165,10 @@ func (l *subjectService) ListExistSubjectsBeforeExpiredAt(
 		return []types.Subject{}, nil
 	}
 
-	idSet := set.NewInt64SetWithValues(existGroupPKs)
+	pkSet := set.NewInt64SetWithValues(existGroupPKs)
 	existSubjects := make([]types.Subject, 0, len(existGroupPKs))
 	for _, group := range groups {
-		if idSet.Has(group.PK) {
+		if pkSet.Has(group.PK) {
 			existSubjects = append(existSubjects, types.Subject{
 				Type: group.Type,
 				ID:   group.ID,

--- a/pkg/service/subject_group.go
+++ b/pkg/service/subject_group.go
@@ -162,7 +162,7 @@ func (l *subjectService) ListExistSubjectsBeforeExpiredAt(
 	existGroupPKs, err := l.relationManager.ListParentPKsBeforeExpiredAt(parentPKs, expiredAt)
 	if err != nil {
 		return []types.Subject{}, errorWrapf(
-			err, "ListParentIDsBeforeExpiredAt _type=`%s`, parentPKs=`%+v`, expiredAt=`%d` fail",
+			err, "ListParentPKsBeforeExpiredAt _type=`%s`, parentPKs=`%+v`, expiredAt=`%d` fail",
 			parentPKs, expiredAt,
 		)
 	}

--- a/pkg/service/subject_group.go
+++ b/pkg/service/subject_group.go
@@ -102,28 +102,23 @@ func (l *subjectService) convertToSubjectGroup(daoRelations []dao.SubjectRelatio
 		return nil, nil
 	}
 
-	subjectPKs := make([]int64, 0, len(daoRelations))
+	parentPKs := make([]int64, 0, len(daoRelations))
 	for _, r := range daoRelations {
-		subjectPKs = append(subjectPKs, r.ParentPK)
+		parentPKs = append(parentPKs, r.ParentPK)
 	}
 
-	subjects, err := l.manager.ListByPKs(subjectPKs)
+	parentMap, err := l.getSubjectMapByPKs(parentPKs)
 	if err != nil {
 		return nil, err
-	}
-
-	subjectMap := make(map[int64]dao.Subject, len(subjects))
-	for _, s := range subjects {
-		subjectMap[s.PK] = s
 	}
 
 	groups := make([]types.SubjectGroup, 0, len(daoRelations))
 	for _, r := range daoRelations {
 		var _type, id string
-		subject, ok := subjectMap[r.SubjectPK]
+		parent, ok := parentMap[r.ParentPK]
 		if ok {
-			_type = subject.Type
-			id = subject.ID
+			_type = parent.Type
+			id = parent.ID
 		}
 
 		groups = append(groups, types.SubjectGroup{

--- a/pkg/service/subject_group_test.go
+++ b/pkg/service/subject_group_test.go
@@ -135,7 +135,7 @@ var _ = Describe("SubjectService", func() {
 			).AnyTimes()
 
 			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
-				[]dao.Subject{}, nil,
+				[]dao.Subject{{PK: 2, Type: "group", ID: "test"}}, nil,
 			).AnyTimes()
 
 			manager := &subjectService{
@@ -145,7 +145,7 @@ var _ = Describe("SubjectService", func() {
 
 			groups, err := manager.ListSubjectGroups("group", "test", int64(0))
 			assert.NoError(GinkgoT(), err)
-			assert.Len(GinkgoT(), groups, 1)
+			assert.Equal(GinkgoT(), []types.SubjectGroup{{PK: 2, Type: "group", ID: "test"}}, groups)
 		})
 	})
 

--- a/pkg/service/subject_group_test.go
+++ b/pkg/service/subject_group_test.go
@@ -11,8 +11,315 @@
 package service
 
 import (
+	"errors"
+	"iam/pkg/database/dao"
+	"iam/pkg/database/dao/mock"
+	"iam/pkg/service/types"
+
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ = Describe("SubjectService", func() {
+	Describe("ListSubjectGroups", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.ListSubjectGroups("group", "test", int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("relationManager.ListRelation fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListRelation(int64(1)).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListSubjectGroups("group", "test", int64(0))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListSubjectGroups")
+		})
+
+		It("relationManager.ListRelationBeforeExpiredAt fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListRelationBeforeExpiredAt(int64(1), int64(10)).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListSubjectGroups("group", "test", int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListSubjectGroups")
+		})
+
+		It("manager.ListByPKs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListRelation(int64(1)).Return(
+				[]dao.SubjectRelation{
+					{
+						PK:       int64(1),
+						ParentPK: int64(2),
+					},
+				}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListSubjectGroups("group", "test", int64(0))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "convertToSubjectGroup")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListRelation(int64(1)).Return(
+				[]dao.SubjectRelation{
+					{
+						PK:       int64(1),
+						ParentPK: int64(2),
+					},
+				}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
+				[]dao.Subject{}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			groups, err := manager.ListSubjectGroups("group", "test", int64(0))
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), groups, 1)
+		})
+	})
+
+	Describe("convertToSubjectGroup", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("empty", func() {
+			manager := &subjectService{}
+
+			groups, err := manager.convertToSubjectGroup([]dao.SubjectRelation{})
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), groups, 0)
+		})
+
+		It("manager.ListByPKs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.convertToSubjectGroup([]dao.SubjectRelation{
+				{
+					PK:       int64(1),
+					ParentPK: int64(2),
+				},
+			})
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "error")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
+				[]dao.Subject{}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			groups, err := manager.convertToSubjectGroup([]dao.SubjectRelation{
+				{
+					PK:       int64(1),
+					ParentPK: int64(2),
+				},
+			})
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), groups, 1)
+		})
+	})
+
+	Describe("ListExistSubjectsBeforeExpiredAt", func() {
+		var ctl *gomock.Controller
+		var subjects []types.Subject
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+
+			subjects = []types.Subject{
+				{
+					Type: "group",
+					ID:   "1",
+				},
+				{
+					Type: "group",
+					ID:   "2",
+				},
+			}
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.ListByIDs", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByIDs("group", []string{"1", "2"}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.ListExistSubjectsBeforeExpiredAt(subjects, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListByIDs")
+		})
+
+		It("relationManager.ListParentPKsBeforeExpiredAt fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByIDs("group", []string{"1", "2"}).Return(
+				[]dao.Subject{
+					{
+						PK:   int64(1),
+						Type: "group",
+						ID:   "1",
+						Name: "1",
+					},
+					{
+						PK:   int64(2),
+						Type: "group",
+						ID:   "2",
+						Name: "2",
+					},
+				}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListParentPKsBeforeExpiredAt([]int64{1, 2}, int64(10)).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListExistSubjectsBeforeExpiredAt(subjects, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListParentPKsBeforeExpiredAt")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByIDs("group", []string{"1", "2"}).Return(
+				[]dao.Subject{
+					{
+						PK:   int64(1),
+						Type: "group",
+						ID:   "1",
+						Name: "1",
+					},
+					{
+						PK:   int64(2),
+						Type: "group",
+						ID:   "2",
+						Name: "2",
+					},
+				}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListParentPKsBeforeExpiredAt([]int64{1, 2}, int64(10)).Return(
+				[]int64{1, 2}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			groups, err := manager.ListExistSubjectsBeforeExpiredAt(subjects, int64(10))
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), []types.Subject{
+				{
+					Type: "group",
+					ID:   "1",
+					Name: "1",
+				},
+				{
+					Type: "group",
+					ID:   "2",
+					Name: "2",
+				},
+			}, groups)
+		})
+	})
 })

--- a/pkg/service/subject_group_test.go
+++ b/pkg/service/subject_group_test.go
@@ -189,7 +189,7 @@ var _ = Describe("SubjectService", func() {
 		It("success", func() {
 			mockSubjectService := mock.NewMockSubjectManager(ctl)
 			mockSubjectService.EXPECT().ListByPKs([]int64{2}).Return(
-				[]dao.Subject{}, nil,
+				[]dao.Subject{{PK: 2, Type: "group", ID: "test"}}, nil,
 			).AnyTimes()
 
 			manager := &subjectService{
@@ -203,7 +203,7 @@ var _ = Describe("SubjectService", func() {
 				},
 			})
 			assert.NoError(GinkgoT(), err)
-			assert.Len(GinkgoT(), groups, 1)
+			assert.Equal(GinkgoT(), []types.SubjectGroup{{PK: 2, Type: "group", ID: "test"}}, groups)
 		})
 	})
 

--- a/pkg/service/subject_group_test.go
+++ b/pkg/service/subject_group_test.go
@@ -12,13 +12,14 @@ package service
 
 import (
 	"errors"
-	"iam/pkg/database/dao"
-	"iam/pkg/database/dao/mock"
-	"iam/pkg/service/types"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+
+	"iam/pkg/database/dao"
+	"iam/pkg/database/dao/mock"
+	"iam/pkg/service/types"
 )
 
 var _ = Describe("SubjectService", func() {

--- a/pkg/service/subject_member.go
+++ b/pkg/service/subject_member.go
@@ -30,12 +30,12 @@ func (l *subjectService) GetMemberCount(_type, id string) (int64, error) {
 		return 0, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
 	}
 
-	cnt, err := l.relationManager.GetMemberCount(pk)
+	count, err := l.relationManager.GetMemberCount(pk)
 	if err != nil {
 		err = errorWrapf(err, "relationManager.GetMemberCount _type=`%s`, id=`%s` fail", _type, id)
 		return 0, err
 	}
-	return cnt, nil
+	return count, nil
 }
 
 // ListPagingMember ...
@@ -288,14 +288,14 @@ func (l *subjectService) GetMemberCountBeforeExpiredAt(_type, id string, expired
 		return 0, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
 	}
 
-	cnt, err := l.relationManager.GetMemberCountBeforeExpiredAt(parentPK, expiredAt)
+	count, err := l.relationManager.GetMemberCountBeforeExpiredAt(parentPK, expiredAt)
 	if err != nil {
 		err = errorx.Wrapf(err, SubjectSVC, "GetMemberCountBeforeExpiredAt",
 			"relationManager.GetMemberCountBeforeExpiredAt _type=`%s`, id=`%s`, expiredAt=`%d` fail",
 			_type, id, expiredAt)
 		return 0, err
 	}
-	return cnt, nil
+	return count, nil
 }
 
 // ListPagingMemberBeforeExpiredAt ...

--- a/pkg/service/subject_member.go
+++ b/pkg/service/subject_member.go
@@ -24,7 +24,7 @@ import (
 // GetMemberCount ...
 func (l *subjectService) GetMemberCount(_type, id string) (int64, error) {
 	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "GetMemberCount")
-	// 查询subject PK
+	// TODO 后续通过缓存提高性能
 	pk, err := l.manager.GetPK(_type, id)
 	if err != nil {
 		return 0, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
@@ -88,6 +88,7 @@ func (l *subjectService) convertToSubjectMembers(daoRelations []dao.SubjectRelat
 		subjectPKs = append(subjectPKs, r.SubjectPK)
 	}
 
+	// TODO 后续通过缓存提高性能
 	subjectMap, err := l.getSubjectMapByPKs(subjectPKs)
 	if err != nil {
 		return nil, err

--- a/pkg/service/subject_member.go
+++ b/pkg/service/subject_member.go
@@ -21,26 +21,18 @@ import (
 	"iam/pkg/service/types"
 )
 
-func convertToSubjectMembers(daoRelations []dao.SubjectRelation) []types.SubjectMember {
-	relations := make([]types.SubjectMember, 0, len(daoRelations))
-	for _, r := range daoRelations {
-		relations = append(relations, types.SubjectMember{
-			PK:              r.PK,
-			Type:            r.SubjectType,
-			ID:              r.SubjectID,
-			PolicyExpiredAt: r.PolicyExpiredAt,
-			CreateAt:        r.CreateAt,
-		})
-	}
-	return relations
-}
-
 // GetMemberCount ...
 func (l *subjectService) GetMemberCount(_type, id string) (int64, error) {
-	cnt, err := l.relationManager.GetMemberCount(_type, id)
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "GetMemberCount")
+	// 查询subject PK
+	pk, err := l.manager.GetPK(_type, id)
 	if err != nil {
-		err = errorx.Wrapf(err, SubjectSVC, "GetMemberCount",
-			"relationManager.GetMemberCount _type=`%s`, id=`%s` fail", _type, id)
+		return 0, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
+	cnt, err := l.relationManager.GetMemberCount(pk)
+	if err != nil {
+		err = errorWrapf(err, "relationManager.GetMemberCount _type=`%s`, id=`%s` fail", _type, id)
 		return 0, err
 	}
 	return cnt, nil
@@ -48,25 +40,88 @@ func (l *subjectService) GetMemberCount(_type, id string) (int64, error) {
 
 // ListPagingMember ...
 func (l *subjectService) ListPagingMember(_type, id string, limit, offset int64) ([]types.SubjectMember, error) {
-	daoRelations, err := l.relationManager.ListPagingMember(_type, id, limit, offset)
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "ListPagingMember")
+	// 查询subject PK
+	pk, err := l.manager.GetPK(_type, id)
 	if err != nil {
-		return nil, errorx.Wrapf(err, SubjectSVC,
-			"ListPagingMember", "relationManager.ListPagingMember _type=`%s`, id=`%s`, limit=`%d`, offset=`%d`",
+		return nil, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
+	daoRelations, err := l.relationManager.ListPagingMember(pk, limit, offset)
+	if err != nil {
+		return nil, errorWrapf(err, "relationManager.ListPagingMember _type=`%s`, id=`%s`, limit=`%d`, offset=`%d`",
 			_type, id, limit, offset)
 	}
 
-	return convertToSubjectMembers(daoRelations), nil
+	relations, err := l.convertToSubjectMembers(daoRelations)
+	if err != nil {
+		return nil, errorWrapf(err, "convertToSubjectMembers relations=`%s`", relations)
+	}
+
+	return relations, nil
+}
+
+func (l *subjectService) convertToSubjectMembers(daoRelations []dao.SubjectRelation) ([]types.SubjectMember, error) {
+	if len(daoRelations) == 0 {
+		return nil, nil
+	}
+
+	subjectPKs := make([]int64, 0, len(daoRelations))
+	for _, r := range daoRelations {
+		subjectPKs = append(subjectPKs, r.SubjectPK)
+	}
+
+	subjects, err := l.manager.ListByPKs(subjectPKs)
+	if err != nil {
+		return nil, err
+	}
+
+	subjectMap := make(map[int64]dao.Subject, len(subjects))
+	for _, s := range subjects {
+		subjectMap[s.PK] = s
+	}
+
+	relations := make([]types.SubjectMember, 0, len(daoRelations))
+	for _, r := range daoRelations {
+		var _type, id string
+		subject, ok := subjectMap[r.SubjectPK]
+		if ok {
+			_type = subject.Type
+			id = subject.ID
+		}
+
+		relations = append(relations, types.SubjectMember{
+			PK:              r.PK,
+			Type:            _type,
+			ID:              id,
+			PolicyExpiredAt: r.PolicyExpiredAt,
+			CreateAt:        r.CreateAt,
+		})
+	}
+	return relations, nil
 }
 
 // ListMember ...
 func (l *subjectService) ListMember(_type, id string) ([]types.SubjectMember, error) {
-	daoRelations, err := l.relationManager.ListMember(_type, id)
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "ListMember")
+	// 查询subject PK
+	pk, err := l.manager.GetPK(_type, id)
+	if err != nil {
+		return nil, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
+	daoRelations, err := l.relationManager.ListMember(pk)
 	if err != nil {
 		return nil, errorx.Wrapf(err, SubjectSVC,
 			"ListMember", "relationManager.ListMember _type=`%s`, id=`%s` fail", _type, id)
 	}
 
-	return convertToSubjectMembers(daoRelations), nil
+	relations, err := l.convertToSubjectMembers(daoRelations)
+	if err != nil {
+		return nil, errorWrapf(err, "convertToSubjectMembers relations=`%s`", relations)
+	}
+
+	return relations, nil
 }
 
 // UpdateMembersExpiredAt ...
@@ -95,6 +150,12 @@ func (l *subjectService) UpdateMembersExpiredAt(members []types.SubjectMember) e
 func (l *subjectService) BulkDeleteSubjectMembers(_type, id string, members []types.Subject) (map[string]int64, error) {
 	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "BulkDeleteSubjectMember")
 
+	// 查询subject PK
+	parentPK, err := l.manager.GetPK(_type, id)
+	if err != nil {
+		return nil, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
 	// 按类型分组
 	userIDs, departmentIDs, _ := groupBySubjectType(members)
 
@@ -113,7 +174,16 @@ func (l *subjectService) BulkDeleteSubjectMembers(_type, id string, members []ty
 
 	var count int64
 	if len(userIDs) != 0 {
-		count, err = l.relationManager.BulkDeleteByMembersWithTx(tx, _type, id, types.UserType, userIDs)
+		users, newErr := l.manager.ListByIDs(types.UserType, userIDs)
+		if newErr != nil {
+			return nil, errorWrapf(newErr, "manager.ListByIDs _type=`%s`, ids=`%+v` fail", types.UserType, userIDs)
+		}
+		subjectPKs := make([]int64, 0, len(users))
+		for _, u := range users {
+			subjectPKs = append(subjectPKs, u.PK)
+		}
+
+		count, err = l.relationManager.BulkDeleteByMembersWithTx(tx, parentPK, subjectPKs)
 		if err != nil {
 			return nil, errorWrapf(err,
 				"relationManager.BulkDeleteByMembersWithTx _type=`%s`, id=`%s`, subjectType=`%s`, subjectIDs=`%+v` fail",
@@ -123,7 +193,16 @@ func (l *subjectService) BulkDeleteSubjectMembers(_type, id string, members []ty
 	}
 
 	if len(departmentIDs) != 0 {
-		count, err = l.relationManager.BulkDeleteByMembersWithTx(tx, _type, id, types.DepartmentType, departmentIDs)
+		departments, newErr := l.manager.ListByIDs(types.DepartmentType, departmentIDs)
+		if newErr != nil {
+			return nil, errorWrapf(newErr, "manager.ListByIDs _type=`%s`, ids=`%+v` fail", types.DepartmentType, departmentIDs)
+		}
+		subjectPKs := make([]int64, 0, len(departments))
+		for _, u := range departments {
+			subjectPKs = append(subjectPKs, u.PK)
+		}
+
+		count, err = l.relationManager.BulkDeleteByMembersWithTx(tx, parentPK, subjectPKs)
 		if err != nil {
 			return nil, errorWrapf(
 				err, "relationManager.BulkDeleteByMembersWithTx _type=`%s`, id=`%s`, subjectType=`%s`, subjectIDs=`%+v` fail",
@@ -147,7 +226,7 @@ func (l *subjectService) BulkCreateSubjectMembers(
 ) error {
 	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "BulkCreateSubjectMembers")
 	// 查询subject PK
-	pk, err := l.manager.GetPK(_type, id)
+	parentPK, err := l.manager.GetPK(_type, id)
 	if err != nil {
 		return errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
 	}
@@ -187,11 +266,7 @@ func (l *subjectService) BulkCreateSubjectMembers(
 		}
 		relations = append(relations, dao.SubjectRelation{
 			SubjectPK:       mPK,
-			SubjectType:     m.Type,
-			SubjectID:       m.ID,
-			ParentPK:        pk,
-			ParentType:      _type,
-			ParentID:        id,
+			ParentPK:        parentPK,
 			PolicyExpiredAt: policyExpiredAt,
 			CreateAt:        now,
 		})
@@ -206,7 +281,14 @@ func (l *subjectService) BulkCreateSubjectMembers(
 
 // GetMemberCountBeforeExpiredAt ...
 func (l *subjectService) GetMemberCountBeforeExpiredAt(_type, id string, expiredAt int64) (int64, error) {
-	cnt, err := l.relationManager.GetMemberCountBeforeExpiredAt(_type, id, expiredAt)
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "GetMemberCountBeforeExpiredAt")
+	// 查询subject PK
+	parentPK, err := l.manager.GetPK(_type, id)
+	if err != nil {
+		return 0, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
+	cnt, err := l.relationManager.GetMemberCountBeforeExpiredAt(parentPK, expiredAt)
 	if err != nil {
 		err = errorx.Wrapf(err, SubjectSVC, "GetMemberCountBeforeExpiredAt",
 			"relationManager.GetMemberCountBeforeExpiredAt _type=`%s`, id=`%s`, expiredAt=`%d` fail",
@@ -220,13 +302,24 @@ func (l *subjectService) GetMemberCountBeforeExpiredAt(_type, id string, expired
 func (l *subjectService) ListPagingMemberBeforeExpiredAt(
 	_type, id string, expiredAt int64, limit, offset int64,
 ) ([]types.SubjectMember, error) {
+	errorWrapf := errorx.NewLayerFunctionErrorWrapf(SubjectSVC, "ListPagingMemberBeforeExpiredAt")
+	// 查询subject PK
+	parentPK, err := l.manager.GetPK(_type, id)
+	if err != nil {
+		return nil, errorWrapf(err, "manager.GetPK _type=`%s`, id=`%s` fail", _type, id)
+	}
+
 	daoRelations, err := l.relationManager.ListPagingMemberBeforeExpiredAt(
-		_type, id, expiredAt, limit, offset)
+		parentPK, expiredAt, limit, offset)
 	if err != nil {
 		return nil, errorx.Wrapf(err, SubjectSVC,
 			"ListPagingMemberBeforeExpiredAt", "_type=`%s`, id=`%s`, expiredAt=`%d`, limit=`%d`, offset=`%d`",
 			_type, id, expiredAt, limit, offset)
 	}
+	relations, err := l.convertToSubjectMembers(daoRelations)
+	if err != nil {
+		return nil, errorWrapf(err, "convertToSubjectMembers relations=`%s`", relations)
+	}
 
-	return convertToSubjectMembers(daoRelations), nil
+	return relations, nil
 }

--- a/pkg/service/subject_member_test.go
+++ b/pkg/service/subject_member_test.go
@@ -13,12 +13,15 @@ package service
 import (
 	"errors"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 
+	"iam/pkg/database"
 	"iam/pkg/database/dao"
 	"iam/pkg/database/dao/mock"
+	"iam/pkg/service/types"
 )
 
 var _ = Describe("SubjectService", func() {
@@ -47,7 +50,7 @@ var _ = Describe("SubjectService", func() {
 			assert.Contains(GinkgoT(), err.Error(), "GetPK")
 		})
 
-		It("manager.ListMember fail", func() {
+		It("relationManager.ListMember fail", func() {
 			mockSubjectService := mock.NewMockSubjectManager(ctl)
 			mockSubjectService.EXPECT().GetPK("group", "test").Return(
 				int64(1), nil,
@@ -116,6 +119,859 @@ var _ = Describe("SubjectService", func() {
 			subjectMembers, err := manager.ListMember("group", "test")
 			assert.NoError(GinkgoT(), err)
 			assert.Len(GinkgoT(), subjectMembers, 1)
+		})
+	})
+
+	Describe("GetMemberCount", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.GetMemberCount("group", "test")
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("relationManager.GetMemberCount fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().GetMemberCount(int64(1)).Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.GetMemberCount("group", "test")
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetMemberCount")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().GetMemberCount(int64(1)).Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			count, err := manager.GetMemberCount("group", "test")
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), int64(1), count)
+		})
+	})
+
+	Describe("ListPagingMember", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.ListPagingMember("group", "test", int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("relationManager.ListPagingMember fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMember(int64(1), int64(0), int64(10)).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListPagingMember("group", "test", int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListPagingMember")
+		})
+
+		It("manager.ListByPKs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMember(int64(1), int64(0), int64(10)).Return(
+				[]dao.SubjectRelation{{}}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListPagingMember("group", "test", int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "convertToSubjectMembers")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				[]dao.Subject{}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMember(int64(1), int64(0), int64(10)).Return(
+				[]dao.SubjectRelation{{}}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			subjectMembers, err := manager.ListPagingMember("group", "test", int64(0), int64(10))
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), subjectMembers, 1)
+		})
+	})
+
+	Describe("convertToSubjectMembers", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("empty", func() {
+			manager := &subjectService{}
+
+			subjects, err := manager.convertToSubjectMembers([]dao.SubjectRelation{})
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), subjects, 0)
+		})
+
+		It("manager.ListByPKs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			subjects, err := manager.convertToSubjectMembers([]dao.SubjectRelation{{}})
+			assert.Error(GinkgoT(), err)
+			assert.Nil(GinkgoT(), subjects)
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				[]dao.Subject{{Type: "test", ID: "id", Name: "name"}}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			subjects, err := manager.convertToSubjectMembers([]dao.SubjectRelation{{}})
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), subjects, 1)
+			assert.Equal(GinkgoT(), "test", subjects[0].Type)
+		})
+	})
+
+	Describe("GetMemberCountBeforeExpiredAt", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.GetMemberCountBeforeExpiredAt("group", "test", int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("relationManager.GetMemberCountBeforeExpiredAt fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().GetMemberCountBeforeExpiredAt(int64(1), int64(10)).Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.GetMemberCountBeforeExpiredAt("group", "test", int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetMemberCountBeforeExpiredAt")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().GetMemberCountBeforeExpiredAt(int64(1), int64(10)).Return(
+				int64(5), nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			count, err := manager.GetMemberCountBeforeExpiredAt("group", "test", int64(10))
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), int64(5), count)
+		})
+	})
+
+	Describe("ListPagingMemberBeforeExpiredAt", func() {
+		var ctl *gomock.Controller
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.ListPagingMemberBeforeExpiredAt("group", "test", int64(10), int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("relationManager.ListMember fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMemberBeforeExpiredAt(int64(1), int64(10), int64(0), int64(10)).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListPagingMemberBeforeExpiredAt("group", "test", int64(10), int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListPagingMemberBeforeExpiredAt")
+		})
+
+		It("manager.ListByPKs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMemberBeforeExpiredAt(int64(1), int64(10), int64(0), int64(10)).Return(
+				[]dao.SubjectRelation{{}}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			_, err := manager.ListPagingMemberBeforeExpiredAt("group", "test", int64(10), int64(0), int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "convertToSubjectMembers")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByPKs([]int64{0}).Return(
+				[]dao.Subject{}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().ListPagingMemberBeforeExpiredAt(int64(1), int64(10), int64(0), int64(10)).Return(
+				[]dao.SubjectRelation{{}}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			subjectMembers, err := manager.ListPagingMemberBeforeExpiredAt("group", "test", int64(10), int64(0), int64(10))
+			assert.NoError(GinkgoT(), err)
+			assert.Len(GinkgoT(), subjectMembers, 1)
+		})
+	})
+
+	Describe("UpdateMembersExpiredAt", func() {
+		var ctl *gomock.Controller
+		var members []types.SubjectMember
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+
+			members = []types.SubjectMember{
+				{
+					PK: int64(1),
+				},
+			}
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("relationManager.UpdateExpiredAt fail", func() {
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().UpdateExpiredAt(gomock.Any()).Return(
+				errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				relationManager: mockSubjectRelationService,
+			}
+
+			err := manager.UpdateMembersExpiredAt(members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "UpdateExpiredAt")
+		})
+
+		It("success", func() {
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().UpdateExpiredAt(gomock.Any()).Return(
+				nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				relationManager: mockSubjectRelationService,
+			}
+
+			err := manager.UpdateMembersExpiredAt(members)
+			assert.NoError(GinkgoT(), err)
+		})
+	})
+
+	Describe("BulkDeleteSubjectMembers", func() {
+		var ctl *gomock.Controller
+		var members []types.Subject
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+
+			members = []types.Subject{
+				{
+					Type: types.UserType,
+					ID:   "user",
+				},
+				{
+					Type: types.DepartmentType,
+					ID:   "department",
+				},
+			}
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			_, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "GetPK")
+		})
+
+		It("manager.ListByIDs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			db, dbMock := database.NewMockSqlxDB()
+			dbMock.ExpectBegin()
+			dbMock.ExpectCommit()
+
+			patches := gomonkey.ApplyFunc(database.GenerateDefaultDBTx, db.Beginx)
+			defer patches.Reset()
+
+			_, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListByIDs")
+		})
+
+		It("relationManager.BulkDeleteByMembersWithTx fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{2}).Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			db, dbMock := database.NewMockSqlxDB()
+			dbMock.ExpectBegin()
+			dbMock.ExpectCommit()
+
+			patches := gomonkey.ApplyFunc(database.GenerateDefaultDBTx, db.Beginx)
+			defer patches.Reset()
+
+			_, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "BulkDeleteByMembersWithTx")
+		})
+
+		It("manager.ListByIDs fail 2", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{2}).Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			db, dbMock := database.NewMockSqlxDB()
+			dbMock.ExpectBegin()
+			dbMock.ExpectCommit()
+
+			patches := gomonkey.ApplyFunc(database.GenerateDefaultDBTx, db.Beginx)
+			defer patches.Reset()
+
+			_, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListByIDs")
+		})
+
+		It("relationManager.BulkDeleteByMembersWithTx fail 2", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{2}).Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				[]dao.Subject{{
+					PK:   int64(3),
+					Type: types.UserType,
+					ID:   "department",
+					Name: "department",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{3}).Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			db, dbMock := database.NewMockSqlxDB()
+			dbMock.ExpectBegin()
+			dbMock.ExpectCommit()
+
+			patches := gomonkey.ApplyFunc(database.GenerateDefaultDBTx, db.Beginx)
+			defer patches.Reset()
+
+			_, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "BulkDeleteByMembersWithTx")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{2}).Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				[]dao.Subject{{
+					PK:   int64(3),
+					Type: types.UserType,
+					ID:   "department",
+					Name: "department",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService.EXPECT().BulkDeleteByMembersWithTx(gomock.Any(), int64(1), []int64{3}).Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			db, dbMock := database.NewMockSqlxDB()
+			dbMock.ExpectBegin()
+			dbMock.ExpectCommit()
+
+			patches := gomonkey.ApplyFunc(database.GenerateDefaultDBTx, db.Beginx)
+			defer patches.Reset()
+
+			typeCount, err := manager.BulkDeleteSubjectMembers("group", "test", members)
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), map[string]int64{
+				"user":       1,
+				"department": 1,
+			}, typeCount)
+		})
+	})
+
+	Describe("BulkCreateSubjectMembers", func() {
+		var ctl *gomock.Controller
+		var members []types.Subject
+		BeforeEach(func() {
+			ctl = gomock.NewController(GinkgoT())
+
+			members = []types.Subject{
+				{
+					Type: types.UserType,
+					ID:   "user",
+				},
+				{
+					Type: types.DepartmentType,
+					ID:   "department",
+				},
+			}
+		})
+		AfterEach(func() {
+			ctl.Finish()
+		})
+
+		It("manager.GetPK fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(0), errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.Error(GinkgoT(), err)
+		})
+
+		It("manager.ListByIDs fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListByIDs")
+		})
+
+		It("manager.ListByIDs fail 2", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				nil, errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "ListByIDs")
+		})
+
+		It("member don't exists pk fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				[]dao.Subject{}, nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager: mockSubjectService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "member don't exists pk")
+		})
+
+		It("relationManager.BulkCreate fail", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				[]dao.Subject{{
+					PK:   int64(3),
+					Type: types.DepartmentType,
+					ID:   "department",
+					Name: "department",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkCreate(gomock.Any()).Return(
+				errors.New("error"),
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.Error(GinkgoT(), err)
+			assert.Contains(GinkgoT(), err.Error(), "BulkCreate")
+		})
+
+		It("success", func() {
+			mockSubjectService := mock.NewMockSubjectManager(ctl)
+			mockSubjectService.EXPECT().GetPK("group", "test").Return(
+				int64(1), nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("user", []string{"user"}).Return(
+				[]dao.Subject{{
+					PK:   int64(2),
+					Type: types.UserType,
+					ID:   "user",
+					Name: "user",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectService.EXPECT().ListByIDs("department", []string{"department"}).Return(
+				[]dao.Subject{{
+					PK:   int64(3),
+					Type: types.DepartmentType,
+					ID:   "department",
+					Name: "department",
+				}}, nil,
+			).AnyTimes()
+
+			mockSubjectRelationService := mock.NewMockSubjectRelationManager(ctl)
+			mockSubjectRelationService.EXPECT().BulkCreate(gomock.Any()).Return(
+				nil,
+			).AnyTimes()
+
+			manager := &subjectService{
+				manager:         mockSubjectService,
+				relationManager: mockSubjectRelationService,
+			}
+
+			err := manager.BulkCreateSubjectMembers("group", "test", members, int64(10))
+			assert.NoError(GinkgoT(), err)
 		})
 	})
 })


### PR DESCRIPTION
## 变更点(Changes)

- 精简subject_relation表字段, 更新相关查询逻辑直接从db中查询
- 补充service层单元测试

---

NOTE: 所有的查询直接走db, 由于缓存模块不在service层, 后续调整, 可以考虑从缓存中读 subjectPK -> subjectType, subjectID

## 相关issues (Which issues this PR fixes)

- Fixes https://github.com/TencentBlueKing/bk-iam-saas/issues/1075

## 备注(Special notes)

