### PR TITLE
feat(auth/securityaudit): change share app code to security audit app

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -97,7 +97,7 @@ func Start() {
 	initSuperAppCode()
 	initSuperUser()
 	initSupportShieldFeatures()
-	initShareAppCode()
+	initSecurityAuditAppCode()
 	initComponents()
 	initQuota()
 	initSwitch()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -151,8 +151,8 @@ func initSupportShieldFeatures() {
 	config.InitSupportShieldFeatures(globalConfig.SupportShieldFeatures)
 }
 
-func initShareAppCode() {
-	config.InitShareAppCode(globalConfig.ShareAppCode)
+func initSecurityAuditAppCode() {
+	config.InitSecurityAuditAppCode(globalConfig.SecurityAuditAppCode)
 }
 
 func initComponents() {

--- a/pkg/api/policy/handler/util.go
+++ b/pkg/api/policy/handler/util.go
@@ -153,7 +153,9 @@ func buildResourceID(rs []resource) string {
 	return strings.Join(nodes, "/")
 }
 
-// ValidateSystemMatchClient ...
+// ValidateSystemMatchClient will check if the client can call the system's policy/[query/auth]
+// note that, the audit app_code can access all system's policy/[query/auth]
+// so, this function should be only called in this module: policy/handler
 func ValidateSystemMatchClient(systemID, clientID string) error {
 	if systemID == "" || clientID == "" {
 		return fmt.Errorf("system_id or client_id do not allow empty")
@@ -162,6 +164,11 @@ func ValidateSystemMatchClient(systemID, clientID string) error {
 	validClients, err := cacheimpls.GetSystemClients(systemID)
 	if err != nil {
 		return fmt.Errorf("get system(%s) valid clients fail, err=%w", systemID, err)
+	}
+
+	// security audit app can be the valid client of all systems
+	if config.SecurityAuditAppCode.Has(clientID) {
+		return nil
 	}
 
 	for _, c := range validClients {

--- a/pkg/api/policy/handler/util_test.go
+++ b/pkg/api/policy/handler/util_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/TencentBlueKing/gopkg/cache"
 	"github.com/TencentBlueKing/gopkg/cache/memory"
+	"github.com/TencentBlueKing/gopkg/collection/set"
 	"github.com/agiledragon/gomonkey/v2"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
@@ -217,7 +218,6 @@ func TestAnyExpression(t *testing.T) {
 }
 
 var _ = Describe("util", func() {
-
 	Describe("validateSystemSuperUser", func() {
 		var patches *gomonkey.Patches
 		BeforeEach(func() {
@@ -279,7 +279,6 @@ var _ = Describe("util", func() {
 	})
 
 	Describe("buildResourceID", func() {
-
 		It("empty", func() {
 			uid := buildResourceID([]resource{})
 			assert.Equal(GinkgoT(), uid, "")
@@ -315,15 +314,15 @@ var _ = Describe("util", func() {
 })
 
 func Test_validateSystemMatchClient(t *testing.T) {
-	var (
-		expiration = 5 * time.Minute
-	)
+	expiration := 5 * time.Minute
 	retrieveFunc := func(key cache.Key) (interface{}, error) {
 		return []string{"test"}, nil
 	}
 	mockCache := memory.NewCache(
 		"mockCache", false, retrieveFunc, expiration, nil)
 	cacheimpls.LocalSystemClientsCache = mockCache
+
+	config.SecurityAuditAppCode = set.NewStringSetWithValues([]string{"audit_app"})
 
 	type args struct {
 		systemID string
@@ -339,6 +338,14 @@ func Test_validateSystemMatchClient(t *testing.T) {
 			args: args{
 				systemID: "test",
 				clientID: "test",
+			},
+			want: true,
+		},
+		{
+			name: "right, secure audit app",
+			args: args{
+				systemID: "test",
+				clientID: "audit_app",
 			},
 			want: true,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,8 +136,8 @@ type Config struct {
 	SuperUser string
 	// 产品上支持接入系统配置屏蔽的功能
 	SupportShieldFeatures []string
-	// 内部系统app_code, 共享权限模型白名单
-	ShareAppCode string
+	// 安全app_code, 共享权限模型白名单, 并且可以作为各个系统合法clients调用权限相关接口
+	SecurityAuditAppCode string
 
 	Databases   []Database
 	DatabaseMap map[string]Database

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -19,7 +19,7 @@ var (
 	SuperAppCodeSet          *set.StringSet
 	SuperUserSet             *set.StringSet
 	SupportShieldFeaturesSet *set.StringSet
-	ShareAppCodeSet          *set.StringSet
+	SecurityAuditAppCode     *set.StringSet
 )
 
 // InitSuperAppCode ...
@@ -56,7 +56,7 @@ func InitSupportShieldFeatures(supportShieldFeatures []string) {
 	SupportShieldFeaturesSet.Append(defaultSupportShieldFeatures...)
 }
 
-// InitShareAppCode read the value from config, parse to set
-func InitShareAppCode(shareAppCode string) {
-	ShareAppCodeSet = set.SplitStringToSet(shareAppCode, ",")
+// InitSecurityAuditAppCode read the value from config, parse to set
+func InitSecurityAuditAppCode(securityAuditAppCode string) {
+	SecurityAuditAppCode = set.SplitStringToSet(securityAuditAppCode, ",")
 }

--- a/pkg/middleware/client.go
+++ b/pkg/middleware/client.go
@@ -55,7 +55,10 @@ func ClientAuthMiddleware(apiGatewayPublicKey []byte) gin.HandlerFunc {
 				return
 			}
 			if len(apiGatewayPublicKey) == 0 {
-				util.UnauthorizedJSONResponse(c, "iam apigateway public key is not configured, not support request from apigateway")
+				util.UnauthorizedJSONResponse(
+					c,
+					"iam apigateway public key is not configured, not support request from apigateway",
+				)
 				c.Abort()
 				return
 			}
@@ -119,8 +122,11 @@ func ShareClientMiddleware() gin.HandlerFunc {
 		log.Debug("Middleware: ShareClientMiddleware")
 
 		appCode := util.GetClientID(c)
-		if !config.ShareAppCodeSet.Has(appCode) {
-			util.UnauthorizedJSONResponse(c, "share client app code wrong, app_code is not in the share client whitelist")
+		if !config.SecurityAuditAppCode.Has(appCode) {
+			util.UnauthorizedJSONResponse(
+				c,
+				"share client app code wrong, app_code is not in the share client whitelist",
+			)
 			c.Abort()
 			return
 		}


### PR DESCRIPTION
扩展原先的功能, security app code 可以
1. 查询所有系统权限模型
2. 调用所有系统的/api/v1/policy/*接口

-------

目的: 审计用

-------

security audit app can fetch all system models and call the /api/v1/policy of all systems

fix #1167


