### PR TITLE
feat(redis/fallback): fallback to database query if redis down

### DIFF
--- a/pkg/abac/prp/group/redis.go
+++ b/pkg/abac/prp/group/redis.go
@@ -69,7 +69,11 @@ func (r *groupAuthTypeRedisRetriever) Retrieve(
 	errorWrapf := errorx.NewLayerFunctionErrorWrapf(RedisLayer, "Retrieve")
 	groupAuthTypes, missPKs, err := r.batchGetGroupAuthType(groupPKs)
 	if err != nil {
-		return nil, errorWrapf(err, "batchGetGroupAuthType fail groupPKs=`%+v`", groupPKs)
+		// 注意, 不能返回err, 失败就失败了, 不影响正常返回
+		// return nil, errorWrapf(err, "batchGetGroupAuthType fail groupPKs=`%+v`", groupPKs)
+		log.WithError(err).
+			Errorf("[%s] batchGetGroupAuthType fail, groupPKs=`%+v`, fallback to database", RedisLayer, groupPKs)
+		missPKs = groupPKs
 	}
 
 	if len(missPKs) > 0 {
@@ -81,7 +85,10 @@ func (r *groupAuthTypeRedisRetriever) Retrieve(
 
 		err = r.batchSetGroupAuthTypeCache(missGroupAuthTypes)
 		if err != nil {
-			return nil, errorWrapf(err, "batchSetGroupAuthTypeCache fail missGroupAuthTypes=`%+v`", missGroupAuthTypes)
+			// 注意, 不能返回err, 失败就失败了, 不影响正常返回
+			// return nil, errorWrapf(err, "batchSetGroupAuthTypeCache fail missGroupAuthTypes=`%+v`", missGroupAuthTypes)
+			log.WithError(err).
+				Errorf("[%s] batchSetGroupAuthTypeCache fail, missGroupAuthTypes=`%+v`", RedisLayer, missGroupAuthTypes)
 		}
 
 		// merge the missGroupAuthTypes to groupAuthTypes

--- a/pkg/cacheimpls/group_resource_policy.go
+++ b/pkg/cacheimpls/group_resource_policy.go
@@ -78,7 +78,10 @@ func retrieveResourceActionAuthorizedGroupPKs(key SystemResourceCacheKey, action
 	groupPKs := actionGroupPKs[actionPK]
 	err = setActionGroupPKs(key, actionPK, groupPKs)
 	if err != nil {
-		return nil, err
+		// 注意, 不能返回err, 失败就失败了, 不影响正常返回
+		// return nil, err
+		log.WithError(err).
+			Errorf("setActionGroupPKs error, key=%s, actionPK=%d, groupPKs=%v", key.Key(), actionPK, groupPKs)
 	}
 
 	return actionGroupPKs[actionPK], nil

--- a/pkg/cacheimpls/system_subject_group.go
+++ b/pkg/cacheimpls/system_subject_group.go
@@ -45,8 +45,16 @@ func ListSystemSubjectEffectGroups(systemID string, pks []int64) ([]types.ThinSu
 
 	cachedSubjectGroups, notExistCachePKs, err := batchGetSystemSubjectGroups(systemID, pks)
 	if err != nil {
-		err = errorWrapf(err, "batchGetSystemSubjectGroups systemID=`%s`, pks=`%+v` fail", systemID, pks)
-		return subjectGroups, err
+		// err = errorWrapf(err, "batchGetSystemSubjectGroups systemID=`%s`, pks=`%+v` fail", systemID, pks)
+		log.WithError(err).Errorf(
+			"batchGetSystemSubjectGroups systemID=`%s`, pks=`%+v` fail, get from cache fail, fallback to database",
+			systemID, pks,
+		)
+
+		// 注意, 不能返回err, 失败就失败了, 不影响正常返回
+		// return subjectGroups, err
+		cachedSubjectGroups = []types.ThinSubjectGroup{}
+		notExistCachePKs = pks
 	}
 	subjectGroups = append(subjectGroups, cachedSubjectGroups...)
 


### PR DESCRIPTION
> 仅放置验证时的代码, 不作为最终的修改, 不要合并

重现步骤: 启动服务, 停掉redis, 测试所有鉴权相关接口正确性; 报错一个, 修一个

需要进一步确认是否覆盖所有场景

related to [#1559](https://github.com/TencentBlueKing/bk-iam-saas/issues/1559)