### PR TITLE
fix(apidoc): System API 生成 的 api path 前缀应该为  /api/v1/model/

### DIFF
--- a/pkg/api/model/handler/action.go
+++ b/pkg/api/model/handler/action.go
@@ -36,7 +36,7 @@ import (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/actions [post]
+// @Router /api/v1/model/systems/{system_id}/actions [post]
 func BatchCreateActions(c *gin.Context) {
 	var body []actionSerializer
 	if err := c.ShouldBindJSON(&body); err != nil {
@@ -123,7 +123,7 @@ func BatchCreateActions(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/action/{action_id} [put]
+// @Router /api/v1/model/systems/{system_id}/action/{action_id} [put]
 func UpdateAction(c *gin.Context) {
 	systemID := c.Param("system_id")
 
@@ -252,7 +252,7 @@ func UpdateAction(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/action/{action_id} [delete]
+// @Router /api/v1/model/systems/{system_id}/action/{action_id} [delete]
 func DeleteAction(c *gin.Context) {
 	systemID := c.Param("system_id")
 	actionID := c.Param("action_id")
@@ -276,7 +276,7 @@ func DeleteAction(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/actions [delete]
+// @Router /api/v1/model/systems/{system_id}/actions [delete]
 func BatchDeleteActions(c *gin.Context) {
 	systemID := c.Param("system_id")
 

--- a/pkg/api/model/handler/instance_selection.go
+++ b/pkg/api/model/handler/instance_selection.go
@@ -38,7 +38,7 @@ import (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/instance-selections [post]
+// @Router /api/v1/model/systems/{system_id}/instance-selections [post]
 func BatchCreateInstanceSelections(c *gin.Context) {
 	var body []instanceSelectionSerializer
 	if err := c.ShouldBindJSON(&body); err != nil {
@@ -114,7 +114,7 @@ func BatchCreateInstanceSelections(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/instance-selections/{instance_selection_id} [put]
+// @Router /api/v1/model/systems/{system_id}/instance-selections/{instance_selection_id} [put]
 func UpdateInstanceSelection(c *gin.Context) {
 	systemID := c.Param("system_id")
 
@@ -197,7 +197,7 @@ func UpdateInstanceSelection(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/instance-selections/{instance_selection_id} [delete]
+// @Router /api/v1/model/systems/{system_id}/instance-selections/{instance_selection_id} [delete]
 func DeleteInstanceSelection(c *gin.Context) {
 	systemID := c.Param("system_id")
 	instanceSelectionID := c.Param("instance_selection_id")

--- a/pkg/api/model/handler/query.go
+++ b/pkg/api/model/handler/query.go
@@ -45,7 +45,7 @@ const (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/query [get]
+// @Router /api/v1/model/systems/{system_id}/query [get]
 //nolint:gocognit
 func SystemInfoQuery(c *gin.Context) {
 	var query querySerializer

--- a/pkg/api/model/handler/resource_type.go
+++ b/pkg/api/model/handler/resource_type.go
@@ -38,7 +38,7 @@ import (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/resource-types [post]
+// @Router /api/v1/model/systems/{system_id}/resource-types [post]
 func BatchCreateResourceTypes(c *gin.Context) {
 	var body []resourceTypeSerializer
 	if err := c.ShouldBindJSON(&body); err != nil {
@@ -117,7 +117,7 @@ func BatchCreateResourceTypes(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/resource-types/{resource_type_id} [put]
+// @Router /api/v1/model/systems/{system_id}/resource-types/{resource_type_id} [put]
 func UpdateResourceType(c *gin.Context) {
 	systemID := c.Param("system_id")
 
@@ -219,7 +219,7 @@ func UpdateResourceType(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/resource-types/{resource_type_id} [delete]
+// @Router /api/v1/model/systems/{system_id}/resource-types/{resource_type_id} [delete]
 func DeleteResourceType(c *gin.Context) {
 	systemID := c.Param("system_id")
 	resourceTypeID := c.Param("resource_type_id")
@@ -242,7 +242,7 @@ func DeleteResourceType(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/resource-types [delete]
+// @Router /api/v1/model/systems/{system_id}/resource-types [delete]
 func BatchDeleteResourceTypes(c *gin.Context) {
 	systemID := c.Param("system_id")
 

--- a/pkg/api/model/handler/system.go
+++ b/pkg/api/model/handler/system.go
@@ -50,7 +50,7 @@ func defaultValidClients(c *gin.Context, originClients string) string {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems [post]
+// @Router /api/v1/model/systems [post]
 func CreateSystem(c *gin.Context) {
 	// validate the body
 	var body systemSerializer
@@ -122,7 +122,7 @@ func CreateSystem(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id} [put]
+// @Router /api/v1/model/systems/{system_id} [put]
 func UpdateSystem(c *gin.Context) {
 	systemID := c.Param("system_id")
 
@@ -210,7 +210,7 @@ func UpdateSystem(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id} [get]
+// @Router /api/v1/model/systems/{system_id} [get]
 func GetSystem(c *gin.Context) {
 	// validate the body
 	systemID := c.Param("system_id")
@@ -253,7 +253,7 @@ func GetSystem(c *gin.Context) {
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/clients [get]
+// @Router /api/v1/model/systems/{system_id}/clients [get]
 func GetSystemClients(c *gin.Context) {
 	// validate the body
 	systemID := c.Param("system_id")

--- a/pkg/api/model/handler/system_config.go
+++ b/pkg/api/model/handler/system_config.go
@@ -49,7 +49,7 @@ const (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/configs/{name} [POST]
+// @Router /api/v1/model/systems/{system_id}/configs/{name} [POST]
 func CreateOrUpdateConfigDispatch(c *gin.Context) {
 	systemID := c.Param("system_id")
 

--- a/pkg/api/model/handler/token.go
+++ b/pkg/api/model/handler/token.go
@@ -32,7 +32,7 @@ import (
 // @Header 200 {string} X-Request-Id "the request id"
 // @Security AppCode
 // @Security AppSecret
-// @Router /api/v1/systems/{system_id}/token [get]
+// @Router /api/v1/model/systems/{system_id}/token [get]
 func GetToken(c *gin.Context) {
 	// validate the body
 	systemID := c.Param("system_id")


### PR DESCRIPTION

## 变更点(Changes)

- pkg/api/model/router Register 方法 上层路由组前缀为 /api/v1/model 但是在 所有的 handler api doc 中 全为/api/v1/systems 

会导致生成的 api doc 路径不对


